### PR TITLE
fix: remove empty allow array from no-console ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,7 +81,7 @@ export default [
     rules: {
       // Disallow bare console.log/warn/error in production code.
       // Use the structured logger (electron/services/logger.cjs) instead.
-      "no-console": ["warn", { allow: [] }],
+      "no-console": "warn",
 
       // Catch variables that are declared but never read
       "no-unused-vars": [


### PR DESCRIPTION
## Summary
- Fixes ESLint 9.39.2 crash caused by empty `allow: []` in the `no-console` rule config
- ESLint requires the `allow` array to have at least 1 item; an empty array crashes ESLint before any linting runs
- This single config bug was breaking all 4 workflows (CI #121, CI #122, Security Scanning #123, Security Scanning #124)

## Change
`eslint.config.js` line 84: `no-console: [

Made with [Cursor](https://cursor.com)warn, { allow: [] }]` changed to `no-console: warn`

## Test plan
- [x] `npx eslint . --quiet` exits cleanly (exit code 0) locally
- [ ] CI workflow lint step passes
- [ ] Security Scanning lint job passes