### PR TITLE
fix: Enterprise-production hardening - auth, session, isolation, error states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,26 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run tests
-        run: npm run test:all
+      - name: Run core tests
+        run: npm test
+
+      - name: Rebuild native modules for Node.js
+        run: npm rebuild better-sqlite3-multiple-ciphers
+
+      - name: Run service tests
+        run: npm run test:services
+
+      - name: Run IPC tests
+        run: npm run test:ipc
+
+      - name: Run load tests
+        run: npm run test:load
+
+      - name: Run component tests
+        run: npm run test:components
+
+      - name: Rebuild for Electron
+        run: npx @electron/rebuild -f
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run lint
 
       - name: Run tests
-        run: npm test
+        run: npm run test:all
 
       - name: Build
         run: npm run build

--- a/electron/functions/index.cjs
+++ b/electron/functions/index.cjs
@@ -777,16 +777,32 @@ async function validateFHIRData(params, context) {
   };
 }
 
+async function logError(params, context) {
+  const { logAudit, currentUser } = context;
+  const { message, stack, componentStack } = params;
+  try {
+    logAudit(
+      'client_error', 'System', null, null,
+      JSON.stringify({ message, stack: (stack || '').substring(0, 500), componentStack: (componentStack || '').substring(0, 500) }),
+      currentUser?.email || 'unknown', currentUser?.role || 'unknown'
+    );
+  } catch {
+    // Best effort - don't let error logging cause more errors
+  }
+  return { logged: true };
+}
+
 module.exports = {
   calculatePriorityAdvanced,
-  calculatePriority: calculatePriorityAdvanced, // Alias
+  calculatePriority: calculatePriorityAdvanced,
   matchDonorAdvanced,
-  matchDonor: matchDonorAdvanced, // Alias
+  matchDonor: matchDonorAdvanced,
   checkNotificationRules,
   exportWaitlist,
   importFHIRData,
   validateFHIRData,
-  exportToFHIR: async (params, context) => ({ success: true, message: 'FHIR export not implemented in offline mode' }),
-  pushToEHR: async (params, context) => ({ success: true, message: 'EHR push not available in offline mode' }),
-  fhirWebhook: async (params, context) => ({ success: true, message: 'Webhooks not available in offline mode' })
+  logError,
+  exportToFHIR: async () => ({ success: true, message: 'FHIR export not implemented in offline mode' }),
+  pushToEHR: async () => ({ success: true, message: 'EHR push not available in offline mode' }),
+  fhirWebhook: async () => ({ success: true, message: 'Webhooks not available in offline mode' })
 };

--- a/electron/ipc/auditReportHandler.cjs
+++ b/electron/ipc/auditReportHandler.cjs
@@ -13,15 +13,20 @@
 const { ipcMain } = require('electron');
 const { getDatabase, getDefaultOrganization } = require('../database/init.cjs');
 const { createLogger } = require('./errorLogger.cjs');
+const shared = require('./shared.cjs');
 
 const log = createLogger('auditReport');
 
 function register() {
   ipcMain.handle('compliance:generate-audit-report', async (_event, options = {}) => {
-    const db = getDatabase();
-    const org = getDefaultOrganization();
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    const { currentUser } = shared.getSessionState();
+    if (!currentUser || !['admin', 'regulator'].includes(currentUser.role)) {
+      throw new Error('Admin or regulator access required for audit reports');
+    }
 
-    if (!org) throw new Error('No organization configured');
+    const db = getDatabase();
+    const orgId = shared.getSessionOrgId();
 
     const {
       startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
@@ -31,8 +36,6 @@ function register() {
       action = null,
       limit = 10000,
     } = options;
-
-    const orgId = org.id;
 
     log.info('Generating compliance audit report', {
       org_id: orgId,
@@ -99,7 +102,7 @@ function register() {
       report_type: 'HIPAA_AUDIT_TRAIL',
       generated_at: new Date().toISOString(),
       organization_id: orgId,
-      organization_name: org.name,
+      organization_name: currentUser.org_name || orgId,
       period: { start: startDate, end: endDate },
       summary: {
         total_entries: totalCount,

--- a/electron/ipc/backupHandler.cjs
+++ b/electron/ipc/backupHandler.cjs
@@ -14,6 +14,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { getDatabase, getDatabasePath, backupDatabase } = require('../database/init.cjs');
 const { createLogger } = require('./errorLogger.cjs');
+const shared = require('./shared.cjs');
 
 const log = createLogger('backup');
 
@@ -93,6 +94,12 @@ function verifyBackupIntegrity(backupPath, encryptionKey) {
 
 function register() {
   ipcMain.handle('backup:create-and-verify', async (_event, options = {}) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    const { currentUser } = shared.getSessionState();
+    if (!currentUser || currentUser.role !== 'admin') {
+      throw new Error('Admin access required for backup operations');
+    }
+
     const { targetPath } = options;
 
     if (!targetPath) {

--- a/electron/ipc/dataResidency.cjs
+++ b/electron/ipc/dataResidency.cjs
@@ -82,16 +82,21 @@ function getOrgResidencyPolicy() {
 }
 
 function register() {
+  const shared = require('./shared.cjs');
+
   ipcMain.handle('residency:getPolicy', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return getOrgResidencyPolicy();
   });
 
   ipcMain.handle('residency:validateDestination', async (_event, url) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const policy = getOrgResidencyPolicy();
     return validateExportDestination(url, policy);
   });
 
   ipcMain.handle('residency:getAvailablePolicies', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return DATA_RESIDENCY_POLICIES;
   });
 }

--- a/electron/ipc/handlers.cjs
+++ b/electron/ipc/handlers.cjs
@@ -77,20 +77,26 @@ function registerExtendedHandlers() {
   });
 
   ipcMain.handle('encryption:getKeyRotationStatus', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return encryptionKeyManagement.getKeyRotationStatus();
   });
 
   ipcMain.handle('encryption:getKeyRotationHistory', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return encryptionKeyManagement.getKeyRotationHistory();
   });
 
   // FHIR R4 validation
   ipcMain.handle('fhir:validate', async (_event, fhirData) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return validateFHIRDataComplete(fhirData);
   });
 
   // Migration status
   ipcMain.handle('system:getMigrationStatus', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    const { currentUser } = shared.getSessionState();
+    if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required');
     const { getDatabase } = require('../database/init.cjs');
     return getMigrationStatus(getDatabase());
   });

--- a/electron/ipc/handlers/license.cjs
+++ b/electron/ipc/handlers/license.cjs
@@ -71,52 +71,86 @@ function register() {
     return result;
   });
 
-  ipcMain.handle('license:isValid', async () => licenseManager.isLicenseValid());
-  ipcMain.handle('license:getTier', async () => licenseManager.getCurrentTier());
+  ipcMain.handle('license:isValid', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.isLicenseValid();
+  });
+  ipcMain.handle('license:getTier', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.getCurrentTier();
+  });
 
   ipcMain.handle('license:getLimits', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const tier = licenseManager.getCurrentTier();
     return licenseManager.getTierLimits(tier);
   });
 
-  ipcMain.handle('license:checkLimit', async (event, limitType, currentCount) => featureGate.canWithinLimit(limitType, currentCount));
-  ipcMain.handle('license:getAppState', async () => featureGate.checkApplicationState());
-  ipcMain.handle('license:getPaymentOptions', async () => licenseManager.getAllPaymentOptions());
-  ipcMain.handle('license:getPaymentInfo', async (event, tier) => licenseManager.getPaymentInfo(tier));
-  ipcMain.handle('license:getOrganization', async () => licenseManager.getOrganizationInfo());
+  ipcMain.handle('license:checkLimit', async (event, limitType, currentCount) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return featureGate.canWithinLimit(limitType, currentCount);
+  });
+  ipcMain.handle('license:getAppState', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return featureGate.checkApplicationState();
+  });
+  ipcMain.handle('license:getPaymentOptions', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.getAllPaymentOptions();
+  });
+  ipcMain.handle('license:getPaymentInfo', async (event, tier) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.getPaymentInfo(tier);
+  });
+  ipcMain.handle('license:getOrganization', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.getOrganizationInfo();
+  });
 
   ipcMain.handle('license:updateOrganization', async (event, updates) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
-    if (currentUser.role !== 'admin') throw new Error('Admin access required');
+    if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required');
     return licenseManager.updateOrganizationInfo(updates);
   });
 
-  ipcMain.handle('license:getMaintenanceStatus', async () => licenseManager.getMaintenanceStatus());
+  ipcMain.handle('license:getMaintenanceStatus', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.getMaintenanceStatus();
+  });
 
   ipcMain.handle('license:getAuditHistory', async (event, limit) => {
-    const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return licenseManager.getLicenseAuditHistory(limit);
   });
 
-  ipcMain.handle('license:isEvaluationBuild', async () => licenseManager.isEvaluationBuild());
+  ipcMain.handle('license:isEvaluationBuild', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return licenseManager.isEvaluationBuild();
+  });
 
-  ipcMain.handle('license:getEvaluationStatus', async () => ({
-    isEvaluation: licenseManager.isEvaluationMode(),
-    daysRemaining: licenseManager.getEvaluationDaysRemaining(),
-    expired: licenseManager.isEvaluationExpired(),
-    inGracePeriod: licenseManager.isInEvaluationGracePeriod(),
-  }));
+  ipcMain.handle('license:getEvaluationStatus', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return {
+      isEvaluation: licenseManager.isEvaluationMode(),
+      daysRemaining: licenseManager.getEvaluationDaysRemaining(),
+      expired: licenseManager.isEvaluationExpired(),
+      inGracePeriod: licenseManager.isInEvaluationGracePeriod(),
+    };
+  });
 
   ipcMain.handle('license:getAllFeatures', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return Object.values(FEATURES).map(feature => ({
       feature,
       ...featureGate.canAccessFeature(feature),
     }));
   });
 
-  ipcMain.handle('license:checkFullAccess', async (event, options) => featureGate.checkFullAccess(options));
+  ipcMain.handle('license:checkFullAccess', async (event, options) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+    return featureGate.checkFullAccess(options);
+  });
 }
 
 module.exports = { register };

--- a/electron/ipc/handlers/operations.cjs
+++ b/electron/ipc/handlers/operations.cjs
@@ -78,10 +78,12 @@ function register() {
   });
 
   ipcMain.handle('compliance:getAuditTrail', async (event, options) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser) throw new Error('Not authenticated');
+    const orgId = shared.getSessionOrgId();
     complianceView.logRegulatorAccess(db, currentUser.id, currentUser.email, 'view_audit', 'Viewed audit trail');
-    return complianceView.getAuditTrailForCompliance(options);
+    return complianceView.getAuditTrailForCompliance({ ...options, orgId });
   });
 
   ipcMain.handle('compliance:getDataCompleteness', async () => {
@@ -91,16 +93,20 @@ function register() {
   });
 
   ipcMain.handle('compliance:getValidationReport', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser) throw new Error('Not authenticated');
+    const orgId = shared.getSessionOrgId();
     complianceView.logRegulatorAccess(db, currentUser.id, currentUser.email, 'view_validation', 'Viewed validation report');
-    return complianceView.generateValidationReport();
+    return complianceView.generateValidationReport(orgId);
   });
 
   ipcMain.handle('compliance:getAccessLogs', async (event, options) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser) throw new Error('Not authenticated');
-    return complianceView.getAccessLogReport(options);
+    const orgId = shared.getSessionOrgId();
+    return complianceView.getAccessLogReport({ ...options, orgId });
   });
 
   // ===== OFFLINE RECONCILIATION =====
@@ -132,6 +138,8 @@ function register() {
 
   // ===== FILE OPERATIONS =====
   ipcMain.handle('file:exportCSV', async (event, data, filename) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
+
     const exportCheck = featureGate.canAccessFeature(FEATURES.DATA_EXPORT);
     if (!exportCheck.allowed) {
       throw new Error('Data export is not available in your current license tier. Please upgrade to export data.');

--- a/electron/ipc/shared.cjs
+++ b/electron/ipc/shared.cjs
@@ -27,6 +27,9 @@ let currentSession = null;
 let currentUser = null;
 let sessionExpiry = null;
 let boundWebContentsId = null;
+let lastActivityTime = null;
+
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
 function getSessionState() {
   return { currentSession, currentUser, sessionExpiry };
@@ -37,6 +40,7 @@ function setSessionState(session, user, expiry, webContentsId) {
   currentUser = user;
   sessionExpiry = expiry;
   boundWebContentsId = webContentsId || null;
+  lastActivityTime = Date.now();
 }
 
 function clearSession() {
@@ -44,6 +48,11 @@ function clearSession() {
   currentUser = null;
   sessionExpiry = null;
   boundWebContentsId = null;
+  lastActivityTime = null;
+}
+
+function touchSession() {
+  if (currentSession) lastActivityTime = Date.now();
 }
 
 function getSessionOrgId() {
@@ -81,6 +90,10 @@ function validateSession(senderWebContentsId) {
     clearSession();
     return false;
   }
+  if (lastActivityTime && (Date.now() - lastActivityTime) > IDLE_TIMEOUT_MS) {
+    clearSession();
+    return false;
+  }
   if (!currentUser.org_id) {
     clearSession();
     return false;
@@ -88,6 +101,18 @@ function validateSession(senderWebContentsId) {
   if (boundWebContentsId && senderWebContentsId && senderWebContentsId !== boundWebContentsId) {
     return false;
   }
+  // Validate session still exists in DB
+  try {
+    const db = getDatabase();
+    const dbSession = db.prepare('SELECT id FROM sessions WHERE id = ? AND user_id = ?').get(currentSession, currentUser.id);
+    if (!dbSession) {
+      clearSession();
+      return false;
+    }
+  } catch {
+    // If DB is unavailable, allow in-memory session to continue
+  }
+  touchSession();
   return true;
 }
 
@@ -360,7 +385,9 @@ module.exports = {
   sessionHasFeature,
   requireFeature,
   validateSession,
+  touchSession,
   SESSION_DURATION_MS,
+  IDLE_TIMEOUT_MS,
   wrapHandler,
 
   // Security

--- a/electron/services/accessControl.cjs
+++ b/electron/services/accessControl.cjs
@@ -248,35 +248,6 @@ function getAllRoles() {
   }));
 }
 
-/**
- * Initialize access control tables
- */
-function initAccessControlTables(db) {
-  // Access justification logs
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS access_justification_logs (
-      id TEXT PRIMARY KEY,
-      user_id TEXT NOT NULL,
-      user_email TEXT,
-      user_role TEXT,
-      permission TEXT NOT NULL,
-      entity_type TEXT,
-      entity_id TEXT,
-      justification_reason TEXT NOT NULL,
-      justification_details TEXT,
-      access_time TEXT DEFAULT (datetime('now')),
-      FOREIGN KEY (user_id) REFERENCES users(id)
-    )
-  `);
-  
-  // Create index for efficient querying
-  db.exec(`
-    CREATE INDEX IF NOT EXISTS idx_access_logs_user ON access_justification_logs(user_id);
-    CREATE INDEX IF NOT EXISTS idx_access_logs_time ON access_justification_logs(access_time DESC);
-    CREATE INDEX IF NOT EXISTS idx_access_logs_entity ON access_justification_logs(entity_type, entity_id);
-  `);
-}
-
 module.exports = {
   PERMISSIONS,
   ROLES,
@@ -288,5 +259,4 @@ module.exports = {
   validateAccessRequest,
   getRolePermissions,
   getAllRoles,
-  initAccessControlTables,
 };

--- a/electron/services/complianceView.cjs
+++ b/electron/services/complianceView.cjs
@@ -77,6 +77,7 @@ function getComplianceSummary(orgId) {
  * Get audit trail for compliance review
  */
 function getAuditTrailForCompliance(options = {}) {
+  if (!options.orgId) throw new Error('Organization context required');
   const db = getDatabase();
   
   let query = `
@@ -84,10 +85,10 @@ function getAuditTrailForCompliance(options = {}) {
       id, action, entity_type, entity_id, patient_name,
       details, user_email, user_role, created_at
     FROM audit_logs
-    WHERE 1=1
+    WHERE org_id = ?
   `;
   
-  const params = [];
+  const params = [options.orgId];
   
   if (options.startDate) {
     query += ' AND created_at >= ?';
@@ -178,13 +179,13 @@ function getDataCompletenessReport(orgId) {
  * Get access log report for compliance
  */
 function getAccessLogReport(options = {}) {
+  if (!options.orgId) throw new Error('Organization context required');
   const db = getDatabase();
   
-  // Check if access justification table exists
   let accessLogs = [];
   try {
-    let query = 'SELECT * FROM access_justification_logs WHERE 1=1';
-    const params = [];
+    let query = 'SELECT * FROM access_justification_logs WHERE org_id = ?';
+    const params = [options.orgId];
     
     if (options.startDate) {
       query += ' AND access_time >= ?';
@@ -204,8 +205,7 @@ function getAccessLogReport(options = {}) {
     }
     
     accessLogs = db.prepare(query).all(...params);
-  } catch (e) {
-    // Table may not exist yet
+  } catch {
     accessLogs = [];
   }
   
@@ -219,7 +219,8 @@ function getAccessLogReport(options = {}) {
 /**
  * Generate formal validation report
  */
-function generateValidationReport() {
+function generateValidationReport(orgId) {
+  if (!orgId) throw new Error('Organization context required');
   const db = getDatabase();
   
   const report = {
@@ -236,13 +237,13 @@ function generateValidationReport() {
       { check: 'Database encryption', status: 'PASS', details: 'SQLite with encryption enabled' },
       { check: 'Audit logging', status: 'PASS', details: 'All data modifications logged' },
       { check: 'Access control', status: 'PASS', details: 'Role-based access control implemented' },
-      { check: 'Session management', status: 'PASS', details: 'Secure session handling with timeout' },
+      { check: 'Session management', status: 'PASS', details: 'Secure session handling with idle timeout' },
     ],
   });
   
   // Section 2: Data Integrity
-  const patientCount = db.prepare('SELECT COUNT(*) as count FROM patients').get().count;
-  const auditCount = db.prepare('SELECT COUNT(*) as count FROM audit_logs').get().count;
+  const patientCount = db.prepare('SELECT COUNT(*) as count FROM patients WHERE org_id = ?').get(orgId).count;
+  const auditCount = db.prepare('SELECT COUNT(*) as count FROM audit_logs WHERE org_id = ?').get(orgId).count;
   
   report.sections.push({
     title: '2. Data Integrity',
@@ -285,9 +286,9 @@ function logRegulatorAccess(db, userId, userEmail, accessType, details) {
   
   const orgId = db.prepare('SELECT org_id FROM users WHERE id = ?').get(userId)?.org_id || 'SYSTEM';
   db.prepare(`
-    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-  `).run(id, orgId, `regulator_${accessType}`, 'Compliance', details, userEmail, 'regulator');
+    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, orgId, `regulator_${accessType}`, 'Compliance', details, userEmail, 'regulator', new Date().toISOString());
   
   return id;
 }

--- a/electron/services/disasterRecovery.cjs
+++ b/electron/services/disasterRecovery.cjs
@@ -361,22 +361,23 @@ function getRecoveryStatus() {
 /**
  * Export data for external backup
  */
-async function exportForExternalBackup() {
+async function exportForExternalBackup(orgId) {
+  if (!orgId) throw new Error('Organization context required for data export');
   const db = getDatabase();
   
   const exportData = {
     exportedAt: new Date().toISOString(),
     version: '1.0.0',
+    organizationId: orgId,
     tables: {},
   };
   
-  // Export all tables
   const tables = ['patients', 'donor_organs', 'matches', 'notifications', 
                   'priority_weights', 'audit_logs', 'users'];
   
   for (const table of tables) {
     try {
-      exportData.tables[table] = db.prepare(`SELECT * FROM ${table}`).all();
+      exportData.tables[table] = db.prepare(`SELECT * FROM ${table} WHERE org_id = ?`).all(orgId);
     } catch (e) {
       logger.error(`Error exporting table ${table}`, { error: e.message });
     }

--- a/electron/services/offlineReconciliation.cjs
+++ b/electron/services/offlineReconciliation.cjs
@@ -47,18 +47,18 @@ const ALLOWED_TABLES = [
 
 // Allowed fields per table (whitelist to prevent SQL injection)
 const ALLOWED_FIELDS = {
-  patients: ['id', 'patient_id', 'first_name', 'last_name', 'date_of_birth', 'blood_type', 'organ_needed', 'medical_urgency', 'waitlist_status', 'date_added_to_waitlist', 'priority_score', 'priority_score_breakdown', 'hla_typing', 'pra_percentage', 'cpra_percentage', 'meld_score', 'las_score', 'functional_status', 'prognosis_rating', 'last_evaluation_date', 'comorbidity_score', 'previous_transplants', 'compliance_score', 'weight_kg', 'height_cm', 'phone', 'email', 'contact_phone', 'contact_email', 'address', 'emergency_contact_name', 'emergency_contact_phone', 'diagnosis', 'comorbidities', 'medications', 'donor_preferences', 'psychological_clearance', 'support_system_rating', 'document_urls', 'notes', 'created_at', 'updated_at', 'created_by', 'updated_by'],
-  donor_organs: ['id', 'donor_id', 'organ_type', 'blood_type', 'hla_typing', 'donor_age', 'donor_weight_kg', 'donor_height_cm', 'cause_of_death', 'cold_ischemia_time_hours', 'organ_condition', 'organ_quality', 'organ_status', 'status', 'recovery_date', 'procurement_date', 'recovery_hospital', 'location', 'expiration_date', 'notes', 'created_date', 'updated_date', 'created_by', 'updated_by'],
-  matches: ['id', 'donor_organ_id', 'patient_id', 'patient_name', 'compatibility_score', 'blood_type_compatible', 'abo_compatible', 'hla_match_score', 'hla_a_match', 'hla_b_match', 'hla_dr_match', 'hla_dq_match', 'size_compatible', 'match_status', 'priority_rank', 'virtual_crossmatch_result', 'physical_crossmatch_result', 'predicted_graft_survival', 'notes', 'created_date', 'updated_date', 'created_by'],
-  notifications: ['id', 'recipient_email', 'title', 'message', 'notification_type', 'is_read', 'related_patient_id', 'related_patient_name', 'priority_level', 'action_url', 'metadata', 'created_date', 'read_date'],
-  notification_rules: ['id', 'rule_name', 'description', 'trigger_event', 'conditions', 'notification_template', 'priority_level', 'is_active', 'created_date', 'updated_date', 'created_by'],
-  priority_weights: ['id', 'name', 'description', 'medical_urgency_weight', 'time_on_waitlist_weight', 'organ_specific_score_weight', 'evaluation_recency_weight', 'blood_type_rarity_weight', 'evaluation_decay_rate', 'is_active', 'created_date', 'updated_date', 'created_by'],
-  ehr_integrations: ['id', 'name', 'type', 'base_url', 'api_key_encrypted', 'is_active', 'last_sync_date', 'sync_frequency_minutes', 'created_date', 'updated_date', 'created_by'],
-  ehr_imports: ['id', 'integration_id', 'import_type', 'status', 'records_imported', 'records_failed', 'error_details', 'import_data', 'created_date', 'completed_date', 'created_by'],
-  ehr_sync_logs: ['id', 'integration_id', 'sync_type', 'direction', 'status', 'records_processed', 'records_failed', 'error_details', 'created_date', 'completed_date'],
-  ehr_validation_rules: ['id', 'field_name', 'rule_type', 'rule_value', 'error_message', 'is_active', 'created_date', 'updated_date', 'created_by'],
-  readiness_barriers: ['id', 'patient_id', 'barrier_type', 'status', 'risk_level', 'owning_role', 'identified_date', 'target_resolution_date', 'resolved_date', 'notes', 'created_by', 'created_at', 'updated_at', 'updated_by'],
-  adult_health_history_questionnaires: ['id', 'patient_id', 'status', 'last_completed_date', 'expiration_date', 'validity_period_days', 'identified_issues', 'owning_role', 'notes', 'created_by', 'created_at', 'updated_at', 'updated_by'],
+  patients: ['id', 'org_id', 'patient_id', 'first_name', 'last_name', 'date_of_birth', 'blood_type', 'organ_needed', 'medical_urgency', 'waitlist_status', 'date_added_to_waitlist', 'priority_score', 'priority_score_breakdown', 'hla_typing', 'pra_percentage', 'cpra_percentage', 'meld_score', 'las_score', 'functional_status', 'prognosis_rating', 'last_evaluation_date', 'comorbidity_score', 'previous_transplants', 'compliance_score', 'weight_kg', 'height_cm', 'phone', 'email', 'contact_phone', 'contact_email', 'address', 'emergency_contact_name', 'emergency_contact_phone', 'diagnosis', 'comorbidities', 'medications', 'donor_preferences', 'psychological_clearance', 'support_system_rating', 'document_urls', 'notes', 'created_at', 'updated_at', 'created_by', 'updated_by'],
+  donor_organs: ['id', 'org_id', 'donor_id', 'organ_type', 'blood_type', 'hla_typing', 'donor_age', 'donor_weight_kg', 'donor_height_cm', 'cause_of_death', 'cold_ischemia_time_hours', 'organ_condition', 'organ_quality', 'organ_status', 'status', 'recovery_date', 'procurement_date', 'recovery_hospital', 'location', 'expiration_date', 'notes', 'created_at', 'updated_at', 'created_by', 'updated_by'],
+  matches: ['id', 'org_id', 'donor_organ_id', 'patient_id', 'patient_name', 'compatibility_score', 'blood_type_compatible', 'abo_compatible', 'hla_match_score', 'hla_a_match', 'hla_b_match', 'hla_dr_match', 'hla_dq_match', 'size_compatible', 'match_status', 'priority_rank', 'virtual_crossmatch_result', 'physical_crossmatch_result', 'predicted_graft_survival', 'notes', 'created_at', 'updated_at', 'created_by'],
+  notifications: ['id', 'org_id', 'recipient_email', 'title', 'message', 'notification_type', 'is_read', 'related_patient_id', 'related_patient_name', 'priority_level', 'action_url', 'metadata', 'created_at', 'read_date'],
+  notification_rules: ['id', 'org_id', 'rule_name', 'description', 'trigger_event', 'conditions', 'notification_template', 'priority_level', 'is_active', 'created_at', 'updated_at', 'created_by'],
+  priority_weights: ['id', 'org_id', 'name', 'description', 'medical_urgency_weight', 'time_on_waitlist_weight', 'organ_specific_score_weight', 'evaluation_recency_weight', 'blood_type_rarity_weight', 'evaluation_decay_rate', 'is_active', 'created_at', 'updated_at', 'created_by'],
+  ehr_integrations: ['id', 'org_id', 'name', 'type', 'base_url', 'api_key_encrypted', 'is_active', 'last_sync_date', 'sync_frequency_minutes', 'created_at', 'updated_at', 'created_by'],
+  ehr_imports: ['id', 'org_id', 'integration_id', 'import_type', 'status', 'records_imported', 'records_failed', 'error_details', 'import_data', 'created_at', 'completed_date', 'created_by'],
+  ehr_sync_logs: ['id', 'org_id', 'integration_id', 'sync_type', 'direction', 'status', 'records_processed', 'records_failed', 'error_details', 'created_at', 'completed_date'],
+  ehr_validation_rules: ['id', 'org_id', 'field_name', 'rule_type', 'rule_value', 'error_message', 'is_active', 'created_at', 'updated_at', 'created_by'],
+  readiness_barriers: ['id', 'org_id', 'patient_id', 'barrier_type', 'status', 'risk_level', 'owning_role', 'identified_date', 'target_resolution_date', 'resolved_date', 'notes', 'created_by', 'created_at', 'updated_at', 'updated_by'],
+  adult_health_history_questionnaires: ['id', 'org_id', 'patient_id', 'status', 'last_completed_date', 'expiration_date', 'validity_period_days', 'identified_issues', 'owning_role', 'notes', 'created_by', 'created_at', 'updated_at', 'updated_by'],
 };
 
 /**
@@ -117,8 +117,8 @@ function setOperationMode(mode) {
   
   const db = getDatabase();
   db.prepare(`
-    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     uuidv4(),
     'SYSTEM',
@@ -126,7 +126,8 @@ function setOperationMode(mode) {
     'System',
     `Operation mode changed: ${previousMode} -> ${mode}`,
     'system',
-    'system'
+    'system',
+    new Date().toISOString()
   );
   
   return { previousMode, currentMode: mode };
@@ -300,32 +301,37 @@ async function reconcilePendingChanges(strategy = CONFLICT_STRATEGY.LATEST_WINS)
       const validData = filterValidFields(change.table, change.data || {});
       
       // Apply the change based on type
+      const changeOrgId = change.orgId || validData.org_id;
+      if (!changeOrgId) {
+        throw new Error('Organization context required for reconciliation');
+      }
+
       switch (change.type) {
         case 'create':
           if (!validData.id) {
             throw new Error('Missing required id field');
           }
-          db.prepare(`INSERT OR IGNORE INTO ${change.table} (id) VALUES (?)`).run(validData.id);
-          // Update with full data (only valid fields)
+          validData.org_id = changeOrgId;
+          db.prepare(`INSERT OR IGNORE INTO ${change.table} (id, org_id) VALUES (?, ?)`).run(validData.id, changeOrgId);
           const createFields = Object.keys(validData).filter(k => k !== 'id');
           if (createFields.length > 0) {
             const createUpdates = createFields.map(k => `${k} = ?`).join(', ');
-            db.prepare(`UPDATE ${change.table} SET ${createUpdates} WHERE id = ?`)
-              .run(...createFields.map(k => validData[k]), validData.id);
+            db.prepare(`UPDATE ${change.table} SET ${createUpdates} WHERE id = ? AND org_id = ?`)
+              .run(...createFields.map(k => validData[k]), validData.id, changeOrgId);
           }
           break;
           
         case 'update':
-          const updateFields = Object.keys(validData).filter(k => k !== 'id');
+          const updateFields = Object.keys(validData).filter(k => k !== 'id' && k !== 'org_id');
           if (updateFields.length > 0) {
             const updates = updateFields.map(k => `${k} = ?`).join(', ');
-            db.prepare(`UPDATE ${change.table} SET ${updates} WHERE id = ?`)
-              .run(...updateFields.map(k => validData[k]), change.entityId);
+            db.prepare(`UPDATE ${change.table} SET ${updates} WHERE id = ? AND org_id = ?`)
+              .run(...updateFields.map(k => validData[k]), change.entityId, changeOrgId);
           }
           break;
           
         case 'delete':
-          db.prepare(`DELETE FROM ${change.table} WHERE id = ?`).run(change.entityId);
+          db.prepare(`DELETE FROM ${change.table} WHERE id = ? AND org_id = ?`).run(change.entityId, changeOrgId);
           break;
           
         default:
@@ -360,8 +366,8 @@ async function reconcilePendingChanges(strategy = CONFLICT_STRATEGY.LATEST_WINS)
   
   // Log reconciliation
   db.prepare(`
-    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     uuidv4(),
     'SYSTEM',
@@ -369,7 +375,8 @@ async function reconcilePendingChanges(strategy = CONFLICT_STRATEGY.LATEST_WINS)
     'System',
     `Reconciliation completed: ${results.succeeded} succeeded, ${results.failed} failed`,
     'system',
-    'system'
+    'system',
+    new Date().toISOString()
   );
   
   return results;
@@ -408,8 +415,12 @@ async function importWithReconciliation(importData, options = {}) {
           continue;
         }
         
-        // Check if record exists
-        const existing = db.prepare(`SELECT * FROM ${table} WHERE id = ?`).get(validRecord.id);
+        if (!validRecord.org_id) {
+          results.errors.push(`Record missing org_id in table ${table}`);
+          results.skipped++;
+          continue;
+        }
+        const existing = db.prepare(`SELECT * FROM ${table} WHERE id = ? AND org_id = ?`).get(validRecord.id, validRecord.org_id);
         
         if (existing) {
           // Detect conflicts
@@ -435,8 +446,8 @@ async function importWithReconciliation(importData, options = {}) {
             const fields = Object.keys(validResolved).filter(k => k !== 'id');
             if (fields.length > 0) {
               const updates = fields.map(k => `${k} = ?`).join(', ');
-              db.prepare(`UPDATE ${table} SET ${updates} WHERE id = ?`)
-                .run(...fields.map(k => validResolved[k]), validRecord.id);
+              db.prepare(`UPDATE ${table} SET ${updates} WHERE id = ? AND org_id = ?`)
+                .run(...fields.map(k => validResolved[k]), validRecord.id, validRecord.org_id);
             }
             
             results.updated++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2233,6 +2234,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -11924,6 +11941,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/pages/ComplianceCenter.jsx
+++ b/src/pages/ComplianceCenter.jsx
@@ -31,7 +31,7 @@ export default function ComplianceCenter() {
     endDate: '',
   });
 
-  const { data: summary, isLoading: loadingSummary } = useQuery({
+  const { data: summary, isLoading: loadingSummary, isError } = useQuery({
     queryKey: ['complianceSummary'],
     queryFn: async () => {
       if (window.electronAPI?.compliance) {
@@ -101,6 +101,17 @@ export default function ComplianceCenter() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
         <RefreshCw className="w-8 h-8 animate-spin text-cyan-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load compliance data. Please try again or contact support.</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -19,7 +19,7 @@ export default function Dashboard() {
 
   const [calculating, setCalculating] = useState(false);
 
-  const { data: patients = [], isLoading, refetch } = useQuery({
+  const { data: patients = [], isLoading, isError, refetch } = useQuery({
     queryKey: ['patients'],
     queryFn: () => api.entities.Patient.list('-priority_score', 500),
   });
@@ -82,6 +82,17 @@ export default function Dashboard() {
     critical: patients.filter(p => (p.priority_score || 0) >= 80).length,
     transplanted: patients.filter(p => p.waitlist_status === 'transplanted').length,
   };
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load dashboard data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">

--- a/src/pages/DisasterRecovery.jsx
+++ b/src/pages/DisasterRecovery.jsx
@@ -23,7 +23,7 @@ export default function DisasterRecovery() {
   const [backupDescription, setBackupDescription] = useState('');
   const queryClient = useQueryClient();
 
-  const { data: status, isLoading } = useQuery({
+  const { data: status, isLoading, isError } = useQuery({
     queryKey: ['recoveryStatus'],
     queryFn: async () => {
       if (window.electronAPI?.recovery) {
@@ -46,7 +46,7 @@ export default function DisasterRecovery() {
 
   const createBackupMutation = useMutation({
     mutationFn: async () => {
-      return await window.electronAPI.recovery.createBackup({
+      return await window.electronAPI?.recovery?.createBackup({
         type: 'manual',
         description: backupDescription || 'Manual backup',
       });
@@ -64,7 +64,7 @@ export default function DisasterRecovery() {
 
   const verifyBackupMutation = useMutation({
     mutationFn: async (backupId) => {
-      return await window.electronAPI.recovery.verifyBackup(backupId);
+      return await window.electronAPI?.recovery?.verifyBackup(backupId);
     },
     onSuccess: (data) => {
       if (data.valid) {
@@ -77,7 +77,7 @@ export default function DisasterRecovery() {
 
   const restoreBackupMutation = useMutation({
     mutationFn: async (backupId) => {
-      return await window.electronAPI.recovery.restoreBackup(backupId);
+      return await window.electronAPI?.recovery?.restoreBackup(backupId);
     },
     onSuccess: (data) => {
       toast.success('Restore completed. Please restart the application.');
@@ -100,6 +100,17 @@ export default function DisasterRecovery() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
         <RefreshCw className="w-8 h-8 animate-spin text-cyan-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load disaster recovery data. Please try again or contact support.</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/DonorMatching.jsx
+++ b/src/pages/DonorMatching.jsx
@@ -19,7 +19,7 @@ export default function DonorMatching() {
   const [matching, setMatching] = useState(false);
   const queryClient = useQueryClient();
 
-  const { data: donors = [], isLoading } = useQuery({
+  const { data: donors = [], isLoading, isError } = useQuery({
     queryKey: ['donors'],
     queryFn: () => api.entities.DonorOrgan.list('-created_at', 100),
   });
@@ -113,6 +113,17 @@ export default function DonorMatching() {
 
   const availableDonors = donors.filter(d => d.status === 'available');
   const allocatedDonors = donors.filter(d => d.status === 'allocated' || d.status === 'transplanted');
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load donor matching data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">

--- a/src/pages/EHRIntegration.jsx
+++ b/src/pages/EHRIntegration.jsx
@@ -11,7 +11,7 @@ import ValidationRuleManager from '../components/ehr/ValidationRuleManager';
 import { format } from 'date-fns';
 
 export default function EHRIntegration() {
-  const { data: user } = useQuery({
+  const { data: user, isError } = useQuery({
     queryKey: ['user'],
     queryFn: () => api.auth.me(),
   });
@@ -24,6 +24,17 @@ export default function EHRIntegration() {
   const handleImportComplete = () => {
     refetchHistory();
   };
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load EHR Integration</h3>
+          <p className="text-red-600">Unable to load EHR integration data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (user?.role !== 'admin') {
     return (

--- a/src/pages/LicenseActivation.jsx
+++ b/src/pages/LicenseActivation.jsx
@@ -91,7 +91,7 @@ export default function LicenseActivation({ onActivated }) {
   const [copied, setCopied] = useState(false);
 
   // Fetch license info
-  const { data: licenseInfo, isLoading: loadingInfo, refetch } = useQuery({
+  const { data: licenseInfo, isLoading: loadingInfo, isError, refetch } = useQuery({
     queryKey: ['licenseInfo'],
     queryFn: async () => {
       if (window.electronAPI?.license) {
@@ -188,6 +188,17 @@ export default function LicenseActivation({ onActivated }) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-cyan-50 via-slate-50 to-cyan-100 flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-cyan-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load License Information</h3>
+          <p className="text-red-600">Unable to load license data. Please try again or contact support.</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/Notifications.jsx
+++ b/src/pages/Notifications.jsx
@@ -17,7 +17,7 @@ export default function Notifications() {
   const [editingRule, setEditingRule] = useState(null);
   const queryClient = useQueryClient();
 
-  const { data: user } = useQuery({
+  const { data: user, isError } = useQuery({
     queryKey: ['user'],
     queryFn: () => api.auth.me(),
   });
@@ -98,6 +98,17 @@ export default function Notifications() {
   };
 
   const unreadCount = notifications.filter(n => !n.is_read).length;
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Notifications</h3>
+          <p className="text-red-600">Unable to load notification data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (user?.role !== 'admin') {
     return (

--- a/src/pages/PatientDetails.jsx
+++ b/src/pages/PatientDetails.jsx
@@ -23,11 +23,11 @@ export default function PatientDetails() {
   const patientId = urlParams.get('id');
   const queryClient = useQueryClient();
 
-  const { data: patient, isLoading } = useQuery({
+  const { data: patient, isLoading, isError } = useQuery({
     queryKey: ['patient', patientId],
     queryFn: async () => {
       const patients = await api.entities.Patient.list();
-      return patients.find(p => p.id === patientId);
+      return patients.find(p => p.id === patientId) ?? null;
     },
     enabled: !!patientId,
   });
@@ -49,6 +49,17 @@ export default function PatientDetails() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
         <div className="text-slate-600">Loading patient details...</div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load patient details. Please try again or contact support.</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/Patients.jsx
+++ b/src/pages/Patients.jsx
@@ -14,7 +14,7 @@ export default function Patients() {
   const [error, setError] = useState(null);
   const queryClient = useQueryClient();
 
-  const { data: patients = [], isLoading, error: queryError } = useQuery({
+  const { data: patients = [], isLoading, isError, error: queryError } = useQuery({
     queryKey: ['patients'],
     queryFn: () => api.entities.Patient.list('-created_at', 500),
   });
@@ -93,6 +93,17 @@ export default function Patients() {
   };
 
   const isMutating = createPatientMutation.isPending || updatePatientMutation.isPending;
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load patient data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">

--- a/src/pages/PrioritySettings.jsx
+++ b/src/pages/PrioritySettings.jsx
@@ -13,7 +13,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 export default function PrioritySettings() {
   const queryClient = useQueryClient();
 
-  const { data: user } = useQuery({
+  const { data: user, isError } = useQuery({
     queryKey: ['user'],
     queryFn: () => api.auth.me(),
   });
@@ -87,6 +87,17 @@ export default function PrioritySettings() {
     formData.blood_type_rarity_weight;
 
   const isValidTotal = totalWeight === 100;
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Priority Settings</h3>
+          <p className="text-red-600">Unable to load priority configuration. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (user?.role !== 'admin') {
     return (

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -18,7 +18,7 @@ export default function Reports() {
   const [exportFormat, setExportFormat] = useState('pdf');
   const [exporting, setExporting] = useState(false);
 
-  const { data: patients = [] } = useQuery({
+  const { data: patients = [], isError } = useQuery({
     queryKey: ['patients'],
     queryFn: () => api.entities.Patient.list('-priority_score', 1000),
   });
@@ -83,6 +83,17 @@ export default function Reports() {
 
     return true;
   });
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Reports</h3>
+          <p className="text-red-600">Unable to load patient data for reports. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">

--- a/src/pages/RiskDashboard.jsx
+++ b/src/pages/RiskDashboard.jsx
@@ -19,7 +19,7 @@ import api from '@/api/localClient';
 export default function RiskDashboard() {
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const { data: dashboard, isLoading, refetch } = useQuery({
+  const { data: dashboard, isLoading, isError, refetch } = useQuery({
     queryKey: ['riskDashboard'],
     queryFn: async () => {
       if (window.electronAPI?.risk) {
@@ -98,6 +98,17 @@ export default function RiskDashboard() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
         <RefreshCw className="w-8 h-8 animate-spin text-cyan-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Data</h3>
+          <p className="text-red-600">Unable to load risk dashboard data. Please try again or contact support.</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -6,7 +6,7 @@ import { Users, Shield, Activity } from 'lucide-react';
 import { format } from 'date-fns';
 
 export default function Settings() {
-  const { data: user } = useQuery({
+  const { data: user, isError } = useQuery({
     queryKey: ['user'],
     queryFn: () => api.auth.me(),
   });
@@ -22,6 +22,17 @@ export default function Settings() {
     queryFn: () => api.entities.AuditLog.list('-created_at', 20),
     enabled: user?.role === 'admin',
   });
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <h3 className="text-red-800 font-semibold text-lg mb-2">Failed to Load Settings</h3>
+          <p className="text-red-600">Unable to load settings data. Please try again or contact support.</p>
+        </div>
+      </div>
+    );
+  }
 
   if (user?.role !== 'admin') {
     return (


### PR DESCRIPTION
## Summary

Enterprise-production hardening pass addressing all remaining security, isolation, and robustness gaps identified in the comprehensive audit.

### Security - Authentication on ALL IPC endpoints
- Added `shared.validateSession()` to every previously unauthenticated handler: `compliance:generate-audit-report`, `backup:create-and-verify`, `file:exportCSV`, all `license:*` handlers, all `residency:*` handlers, `encryption:getKeyRotationStatus/History`, `fhir:validate`, `system:getMigrationStatus`
- Added admin/regulator role checks on sensitive endpoints (audit reports, backups, migrations)

### Security - Session hardening
- `validateSession()` now checks session exists in DB `sessions` table (prevents use of revoked sessions)
- Added 15-minute idle timeout (`IDLE_TIMEOUT_MS`) with `touchSession()` on every validated request
- Session activity tracking via `lastActivityTime`

### Data Isolation - Cross-tenant leak fixes
- `complianceView.getAuditTrailForCompliance()` now requires and filters by `orgId`
- `complianceView.getAccessLogReport()` now requires and filters by `orgId`
- `complianceView.generateValidationReport()` now requires and filters by `orgId`
- `disasterRecovery.exportForExternalBackup()` now requires `orgId` and filters all table exports
- `offlineReconciliation` UPDATE/DELETE/INSERT queries now include `AND org_id = ?`
- Added `org_id` to all ALLOWED_FIELDS whitelists in offlineReconciliation
- Fixed date field names (created_date/updated_date -> created_at/updated_at) in whitelists

### Error Handling - Frontend robustness
- Added `isError` state and error UI to all 14 remaining pages (Dashboard, Patients, PatientDetails, DonorMatching, ComplianceCenter, RiskDashboard, DisasterRecovery, Settings, Notifications, EHRIntegration, Reports, PrioritySettings, LicenseActivation)
- Added optional chaining on `window.electronAPI` in DisasterRecovery mutations
- Fixed react-query v5 `undefined` return bug in PatientDetails queryFn

### Other fixes
- Registered `logError` function in `functions/index.cjs` (fixes broken ErrorBoundary error reporting)
- Removed dead `initAccessControlTables` code from accessControl.cjs
- Standardized audit log inserts to use ISO 8601 timestamps
- CI now runs `test:all` instead of just `test` (includes service tests, component tests, load tests)
- Added `@playwright/test` to devDependencies

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run test:services` passes all 39 tests
- [ ] `npx vitest run` passes all 60 component tests (including PatientDetails "not found" fix)
- [ ] All IPC endpoints reject unauthenticated requests
- [ ] Session expires after 15 min idle
- [ ] Compliance audit trail only returns current org's data
- [ ] All 18 pages show proper error states on API failure
