### PR TITLE
Final session hardening: upgrade all IPC handlers to full validation

### DIFF
--- a/electron/ipc/handlers.cjs
+++ b/electron/ipc/handlers.cjs
@@ -66,6 +66,7 @@ function registerExtendedHandlers() {
 
   // Encryption key rotation
   ipcMain.handle('encryption:rotateKey', async (_event, options = {}) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser || currentUser.role !== 'admin') {
       throw new Error('Admin access required for key rotation');

--- a/electron/ipc/handlers/operations.cjs
+++ b/electron/ipc/handlers/operations.cjs
@@ -18,14 +18,14 @@ function register() {
 
   // ===== ACCESS CONTROL =====
   ipcMain.handle('access:validateRequest', async (event, permission, justification) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
     return accessControl.validateAccessRequest(currentUser.role, permission, justification);
   });
 
   ipcMain.handle('access:logJustifiedAccess', async (event, permission, entityType, entityId, justification) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
     return accessControl.logAccessWithJustification(
       db, currentUser.id, currentUser.email, currentUser.role,
       permission, entityType, entityId, justification
@@ -43,9 +43,10 @@ function register() {
 
   // ===== DISASTER RECOVERY =====
   ipcMain.handle('recovery:createBackup', async (event, options) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
-    return await disasterRecovery.createBackup({ ...options, createdBy: currentUser.email });
+    if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required for backup');
+    return await disasterRecovery.createBackup({ ...options, createdBy: currentUser.email, orgId: shared.getSessionOrgId() });
   });
 
   ipcMain.handle('recovery:listBackups', async () => {
@@ -59,6 +60,7 @@ function register() {
   });
 
   ipcMain.handle('recovery:restoreBackup', async (event, backupId) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required for restore');
     return await disasterRecovery.restoreFromBackup(backupId, { restoredBy: currentUser.email });
@@ -71,8 +73,8 @@ function register() {
 
   // ===== COMPLIANCE VIEW =====
   ipcMain.handle('compliance:getSummary', async () => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
     complianceView.logRegulatorAccess(db, currentUser.id, currentUser.email, 'view_summary', 'Viewed compliance summary');
     return complianceView.getComplianceSummary(shared.getSessionOrgId());
   });
@@ -87,8 +89,7 @@ function register() {
   });
 
   ipcMain.handle('compliance:getDataCompleteness', async () => {
-    const { currentUser } = shared.getSessionState();
-    if (!currentUser) throw new Error('Not authenticated');
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     return complianceView.getDataCompletenessReport(shared.getSessionOrgId());
   });
 
@@ -120,12 +121,14 @@ function register() {
   });
 
   ipcMain.handle('reconciliation:reconcile', async (event, strategy) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required');
     return await offlineReconciliation.reconcilePendingChanges(strategy);
   });
 
   ipcMain.handle('reconciliation:setMode', async (event, mode) => {
+    if (!shared.validateSession()) throw new Error('Session expired. Please log in again.');
     const { currentUser } = shared.getSessionState();
     if (!currentUser || currentUser.role !== 'admin') throw new Error('Admin access required');
     return offlineReconciliation.setOperationMode(mode);

--- a/electron/services/disasterRecovery.cjs
+++ b/electron/services/disasterRecovery.cjs
@@ -56,9 +56,13 @@ async function createBackup(options = {}) {
   const backupPath = path.join(backupDir, backupFileName);
   const metadataPath = path.join(backupDir, `${backupFileName}.meta.json`);
   
-  // Get database stats
-  const patientCount = db.prepare('SELECT COUNT(*) as count FROM patients').get().count;
-  const auditCount = db.prepare('SELECT COUNT(*) as count FROM audit_logs').get().count;
+  const orgId = options.orgId || 'SYSTEM';
+  const patientCount = orgId !== 'SYSTEM'
+    ? db.prepare('SELECT COUNT(*) as count FROM patients WHERE org_id = ?').get(orgId).count
+    : db.prepare('SELECT COUNT(*) as count FROM patients').get().count;
+  const auditCount = orgId !== 'SYSTEM'
+    ? db.prepare('SELECT COUNT(*) as count FROM audit_logs WHERE org_id = ?').get(orgId).count
+    : db.prepare('SELECT COUNT(*) as count FROM audit_logs').get().count;
   
   // Create backup using SQLite backup API
   await db.backup(backupPath);
@@ -89,16 +93,17 @@ async function createBackup(options = {}) {
   
   // Log backup in audit trail
   db.prepare(`
-    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     uuidv4(),
-    options.orgId || 'SYSTEM',
+    orgId,
     'backup_created',
     'System',
     `Backup created: ${backupFileName} (${patientCount} patients, checksum: ${checksum.substring(0, 16)}...)`,
     options.createdBy || 'system',
-    'system'
+    'system',
+    new Date().toISOString()
   );
   
   // Cleanup old backups if auto-backup
@@ -279,8 +284,8 @@ async function restoreFromBackup(backupId, options = {}) {
   
   // Log restore attempt
   db.prepare(`
-    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO audit_logs (id, org_id, action, entity_type, details, user_email, user_role, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     uuidv4(),
     options.orgId || 'SYSTEM',
@@ -288,7 +293,8 @@ async function restoreFromBackup(backupId, options = {}) {
     'System',
     `Restore initiated from: ${backup.fileName}`,
     options.restoredBy || 'system',
-    'system'
+    'system',
+    new Date().toISOString()
   );
   
   // Close current database


### PR DESCRIPTION
## Summary
- Upgraded 8 IPC handlers from weak currentUser-only checks to full validateSession() (expiry, idle timeout, DB-backed session verification)
- Added admin role gate to recovery:createBackup
- Fixed disasterRecovery COUNT(*) queries to scope by org_id when available
- Added explicit ISO timestamps to all disasterRecovery audit log inserts

## Affected handlers
- access:validateRequest, access:logJustifiedAccess
- recovery:createBackup, recovery:restoreBackup
- compliance:getSummary, compliance:getDataCompleteness
- reconciliation:reconcile, reconciliation:setMode
- encryption:rotateKey

## Test plan
- [ ] Verify session expiry is enforced on all above handlers
- [ ] Verify idle timeout (15 min) applies to all above handlers
- [ ] Verify backup metadata counts are org-scoped
- [ ] Verify audit log timestamps are ISO format

Made with [Cursor](https://cursor.com)