### PR TITLE
legal: enforce proprietary licensing and anti-impersonation notice

### DIFF
--- a/LEGAL_NOTICE.md
+++ b/LEGAL_NOTICE.md
@@ -1,0 +1,56 @@
+# Legal Notice and Authorized Use
+
+This notice provides additional legal and operational guidance for TransTrack.
+It does not replace legal counsel and does not waive any rights.
+
+## Ownership
+
+TransTrack and TransTrackMedical-TransTrack are owned by TransTrack Medical Software.
+All rights are reserved except where explicitly granted in writing.
+
+## License and Activation Requirement
+
+Use, operation, deployment, redistribution, and commercialization of this software
+require explicit written authorization and a valid activation/license entitlement
+issued by TransTrack Medical Software.
+
+Any use without valid authorization and activation is unauthorized.
+
+## No Impersonation / No Passing Off
+
+No person or entity may:
+
+- Claim TransTrack as their own software
+- Present themselves as an official TransTrack distributor or maintainer
+- Rebrand or publish confusingly similar copies under TransTrack identity
+- Distribute altered builds while implying official origin
+
+## Authorized Channels
+
+Official channels are limited to:
+
+- Repository: https://github.com/NeuroKoder3/TransTrackMedical-TransTrack
+- Releases: https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases
+- Contact: Trans_Track@outlook.com
+
+Any other page claiming to be official should be treated as untrusted.
+
+Known unaffiliated page reported by users:
+
+- https://the-vishal-gupta.github.io/
+
+Do not download software from unaffiliated pages.
+
+## Security Warning
+
+If you encounter a suspicious page or file using TransTrack branding:
+
+1. Do not execute downloaded files.
+2. Collect URL, timestamp, and screenshots.
+3. Preserve file hashes if files were downloaded.
+4. Report details to Trans_Track@outlook.com.
+
+## Enforcement
+
+Unauthorized use may be addressed through copyright, trademark, abuse-report,
+and other lawful enforcement channels, including takedown requests and legal action.

--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,46 @@
-MIT License
-
+TransTrack Proprietary License v1.0
 Copyright (c) 2026 TransTrack Medical Software
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+IMPORTANT:
+This software and all related assets, names, branding, documentation, and
+compiled artifacts are proprietary. No person or organization may use,
+reproduce, modify, distribute, sublicense, sell, host, publish, or operate
+this software (in source or binary form) except under an explicit written
+license agreement issued by TransTrack Medical Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1) No unauthorized use
+- You may NOT claim this program as your own.
+- You may NOT redistribute this program under the same or confusingly similar
+  identity.
+- You may NOT publish this program or derivatives under the TransTrack or
+  TransTrackMedical names without written authorization.
 
+2) Activation and license requirement
+- Use of this program requires a valid activation and license entitlement from
+  TransTrack Medical Software.
+- Any use without a valid activation/license is unauthorized.
+
+3) No implied permissions
+- No patent, trademark, service-mark, trade dress, branding, or other
+  intellectual property rights are granted by this file.
+- Public visibility of this repository does NOT grant permission to use,
+  copy, or distribute this software.
+
+4) Authorized channels
+Only the following channels are authorized:
+- Repository: https://github.com/NeuroKoder3/TransTrackMedical-TransTrack
+- Releases: https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases
+- Contact: Trans_Track@outlook.com
+
+5) Enforcement
+Unauthorized use may result in takedown requests, account/platform abuse
+reports, and legal action to the fullest extent permitted by law.
+
+6) Disclaimer
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-Note: TransTrack is offered free of charge with all features unlocked. There
-is no license activation, no pricing, and no usage tiers. The Software is not
-intended for clinical decision-making or as a replacement for UNOS/OPTN
-allocation systems.
+IMPLIED, INCLUDING BUT NOT LIMITED TO MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION
+WITH THE SOFTWARE OR ITS USE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ TransTrack is an offline-first desktop application for transplant centers and pr
 
 > **Important:** "HIPAA aligned" and "Part 11 architected" describe the product's design controls — they are not certifications. SOC 2 / HITRUST / 21 CFR Part 11 validation, and any FDA determinations, must be performed by the deploying organization with qualified auditors.
 
-TransTrack is free to download and use — no license keys, activation codes, or subscriptions required. All features are fully unlocked for everyone.
+> **Licensing Notice:** TransTrack is proprietary software. Use, operation, and deployment require a valid license activation issued by TransTrack Medical Software. Unauthorized use, redistribution, or rebranding is prohibited.
+
+> **Impersonation and Safety Warning:** The project has identified unaffiliated third-party pages impersonating TransTrack. Do not download installers, archives, or updates from unofficial pages. Use only the official repository and releases listed below.
+
+> **Known Unaffiliated Page (Do Not Use):** `https://the-vishal-gupta.github.io/` is not an authorized TransTrack channel. Treat downloads or links from that page as unsafe.
 
 <p align="center">
   <img src="docs/images/dashboard-preview.svg" alt="TransTrack Dashboard" width="800">
@@ -232,6 +236,8 @@ All metrics are computed locally from the encrypted SQLite database. No cloud, A
 
 Download from the [Releases page](https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases).
 
+Only this GitHub Releases page is an authorized download channel.
+
 | Platform              | File                         |
 | --------------------- | ---------------------------- |
 | Windows (x64)         | `TransTrack-1.0.0-x64.exe`   |
@@ -274,6 +280,14 @@ npm run build:electron
 4. Begin entering or importing data — all features are immediately available.
 
 Contact [Trans_Track@outlook.com](mailto:Trans_Track@outlook.com) if you need assistance.
+
+## Trust and Anti-Impersonation Notice
+
+- Official repository: `https://github.com/NeuroKoder3/TransTrackMedical-TransTrack`
+- Official releases: `https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases`
+- Official support email: `Trans_Track@outlook.com`
+- Any lookalike page claiming to be "official TransTrack" outside these channels should be treated as untrusted.
+- If you suspect malware, impersonation, or fraud linked to TransTrack branding, report it immediately to `Trans_Track@outlook.com`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,26 @@
 - Initial assessment: Within 1 week
 - Resolution target: Based on severity (Critical: 24h, High: 72h, Medium: 1 week, Low: 30 days)
 
+## Trusted Distribution and Impersonation Alerts
+
+- Official repository: `https://github.com/NeuroKoder3/TransTrackMedical-TransTrack`
+- Official release channel: `https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases`
+- Official contact: `Trans_Track@outlook.com`
+
+Any third-party page, mirror, or download host claiming to be "official
+TransTrack" outside the channels above is untrusted and may pose a malware or
+supply-chain risk.
+
+Known unaffiliated page currently reported by users:
+- `https://the-vishal-gupta.github.io/`
+- Do not download files or follow software links from this page.
+
+If you encounter a suspicious page, report:
+1. URL and timestamp
+2. Screenshots
+3. Downloaded file hashes (if any)
+4. Any observed malicious behavior
+
 ## Supported Versions
 
 | Version | Supported |

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,6 +1,6 @@
 # TransTrack / TransTrackMedical Trademark Notice
 
-This file gives third parties constructive notice of the unregistered (common-law) trademarks used by the TransTrack project, the date of first use in commerce, and the limits of the permission granted by the project's source-code license.
+This file gives third parties constructive notice of the unregistered (common-law) trademarks used by the TransTrack project, the date of first use in commerce, and the limits of the permission granted by the project's software license.
 
 This notice is published in good faith. It is not legal advice, and it does not modify the terms of the [`LICENSE`](LICENSE) file in this repository.
 
@@ -49,11 +49,11 @@ The **only** authoritative distribution channel for compiled installers is the G
 
 Any other email address, support page, "purchase" page, payment link, archive, installer, or "official" channel that claims to represent TransTrack — including but not limited to addresses at the domains `transtrackmedical.org`, `transtrack.org`, `transtrackmedical.com`, or any payment link not published from this repository — is **not** affiliated with this project and should be treated as fraudulent.
 
-## 4. Relationship to the source-code license
+## 4. Relationship to the software license
 
-The TransTrack source code in this repository is offered under the [MIT License](LICENSE). The MIT License is a copyright license. It applies to the **source code only**. It does **not** grant any trademark, brand, logo, identity, or "designation of origin" rights.
+The TransTrack software in this repository is governed by the [LICENSE](LICENSE) file in this repository. The software license does not grant any trademark, brand, logo, identity, or "designation of origin" rights.
 
-In particular, the MIT License does not grant any person permission to:
+In particular, the software license does not grant any person permission to:
 
 - a) host, distribute, sell, or "support" any compiled binary, installer, archive, or service under the TransTrack / TransTrackMedical names that is not built directly from a tagged release of this repository;
 - b) operate any landing page, download page, GitHub Pages site, web property, or "official" support channel under the TransTrack / TransTrackMedical names;
@@ -61,7 +61,7 @@ In particular, the MIT License does not grant any person permission to:
 - d) represent themselves as the TransTrack project, its maintainers, "TransTrack Medical Software," or any agent thereof;
 - e) use the TransTrack / TransTrackMedical names, marks, logos, descriptive copy, screenshots, or product identity in any manner likely to cause confusion as to the source of goods or services.
 
-Forks of the source code under a **clearly distinct, non-confusing project name and brand** are welcome under the MIT terms. Forks that retain the TransTrack name, branding, or descriptive identity are not.
+Any reuse, redistribution, or operation without explicit written authorization and valid activation/license entitlement is prohibited.
 
 ## 5. Enforcement
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.0",
   "private": true,
   "author": "TransTrack Medical Software",
-  "license": "MIT",
+  "license": "Proprietary",
   "homepage": "https://github.com/NeuroKoder3/TransTrackMedical-TransTrack",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- replace MIT license text with a proprietary license notice that requires explicit authorization and activation/license entitlement
- add a new `LEGAL_NOTICE.md` and update `README.md`, `SECURITY.md`, and `TRADEMARK.md` with trusted-channel, anti-impersonation, and safety warnings
- update package metadata to mark the project license as `Proprietary`

## Test plan
- [x] Verify documentation files render correctly in markdown
- [x] Confirm `package.json` license field is updated
- [x] Ensure legal and warning language points to official repository/release channels