### PR TITLE
fix(security): resolve CodeQL missing rate-limiting alert in server bootstrap

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -106,6 +106,8 @@ async function build() {
   });
 
   const authHook = makeAuthHook(config);
+  const authRateLimitHook = app.rateLimit({ max: 200, timeWindow: '1 minute' });
+  app.addHook('preHandler', authRateLimitHook);
   app.addHook('preHandler', authHook);
 
   app.register(require('./routes/health'));


### PR DESCRIPTION
## Summary
- add an explicit Fastify rate-limit preHandler immediately before the authorization preHandler in `server/src/index.js`
- preserve existing auth behavior while giving CodeQL an explicit throttling control at the flagged location

## Test plan
- [x] `npm --prefix server run lint`
- [x] `npm --prefix server run test`