### PR TITLE
feat(epic): wire Observation/Condition/MedicationRequest/AllergyIntolerance into native tables

### DIFF
--- a/server/src/db/migrations/007_clinical_detail.sql
+++ b/server/src/db/migrations/007_clinical_detail.sql
@@ -1,0 +1,145 @@
+-- =============================================================================
+-- 007_clinical_detail.sql
+-- Native relational tables for patient conditions, medications, and allergies.
+--
+-- Prior to this migration these resource types were imported from Epic and
+-- other EHR sources but only stored as opaque JSON in fhir_resources. They
+-- are now also materialised into structured rows so that:
+--   - the inactivation risk engine can inspect active problem lists and
+--     nephrotoxic / immunosuppressive medication lists
+--   - CDS Hooks services can query conditions and allergies without parsing
+--     JSONB blobs at query time
+--   - OPTN export templates can reference structured clinical context
+--
+-- Sources: FHIR_R4 (Epic import, direct FHIR POST), HL7_V2, MANUAL entry.
+-- All tables follow the same org-scoped, RLS-protected pattern as 002_clinical.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- patient_conditions
+-- Materialised from FHIR R4 Condition resources. code/system follow SNOMED-CT
+-- or ICD-10-CM as sent by the originating EHR. clinical_status mirrors the
+-- FHIR valueset: active | recurrence | relapse | inactive | remission |
+-- resolved. category mirrors: problem-list-item | encounter-diagnosis.
+-- ---------------------------------------------------------------------------
+CREATE TABLE patient_conditions (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id              UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    patient_id          UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    code                TEXT NOT NULL,
+    code_system         TEXT,
+    display             TEXT,
+    clinical_status     TEXT,
+    verification_status TEXT,
+    category            TEXT,
+    onset_date          DATE,
+    abatement_date      DATE,
+    notes               TEXT,
+    source              TEXT NOT NULL DEFAULT 'MANUAL'
+                        CHECK (source IN ('MANUAL', 'FHIR_R4', 'HL7_V2')),
+    fhir_resource_id    TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_conditions_patient     ON patient_conditions(org_id, patient_id, onset_date DESC);
+CREATE INDEX idx_conditions_code        ON patient_conditions(org_id, patient_id, code);
+CREATE INDEX idx_conditions_status      ON patient_conditions(org_id, patient_id, clinical_status);
+
+CREATE TRIGGER patient_conditions_updated BEFORE UPDATE ON patient_conditions
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- patient_medications
+-- Materialised from FHIR R4 MedicationRequest resources. medication_code /
+-- code_system follow RxNorm (system urn:oid:2.16.840.1.113883.6.88) as
+-- returned by Epic. status mirrors the FHIR MedicationRequest.status
+-- valueset: active | on-hold | cancelled | completed | stopped | draft.
+-- ---------------------------------------------------------------------------
+CREATE TABLE patient_medications (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id            UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    patient_id        UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    medication_code   TEXT,
+    code_system       TEXT,
+    medication_name   TEXT NOT NULL,
+    status            TEXT,
+    intent            TEXT,
+    dosage_text       TEXT,
+    frequency         TEXT,
+    route             TEXT,
+    authored_on       DATE,
+    prescriber        TEXT,
+    notes             TEXT,
+    source            TEXT NOT NULL DEFAULT 'MANUAL'
+                      CHECK (source IN ('MANUAL', 'FHIR_R4', 'HL7_V2')),
+    fhir_resource_id  TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_medications_patient    ON patient_medications(org_id, patient_id, authored_on DESC);
+CREATE INDEX idx_medications_name       ON patient_medications(org_id, patient_id, medication_name);
+CREATE INDEX idx_medications_status     ON patient_medications(org_id, patient_id, status);
+
+CREATE TRIGGER patient_medications_updated BEFORE UPDATE ON patient_medications
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- patient_allergies
+-- Materialised from FHIR R4 AllergyIntolerance resources. criticality mirrors
+-- the FHIR valueset: low | high | unable-to-assess. allergy_type: allergy |
+-- intolerance. category: food | medication | environment | biologic.
+-- ---------------------------------------------------------------------------
+CREATE TABLE patient_allergies (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id                UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    patient_id            UUID NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+    code                  TEXT,
+    code_system           TEXT,
+    display               TEXT NOT NULL,
+    allergy_type          TEXT,
+    category              TEXT,
+    criticality           TEXT,
+    clinical_status       TEXT,
+    verification_status   TEXT,
+    reaction_description  TEXT,
+    onset_date            DATE,
+    notes                 TEXT,
+    source                TEXT NOT NULL DEFAULT 'MANUAL'
+                          CHECK (source IN ('MANUAL', 'FHIR_R4', 'HL7_V2')),
+    fhir_resource_id      TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_allergies_patient      ON patient_allergies(org_id, patient_id);
+CREATE INDEX idx_allergies_code         ON patient_allergies(org_id, patient_id, code);
+CREATE INDEX idx_allergies_criticality  ON patient_allergies(org_id, patient_id, criticality);
+
+CREATE TRIGGER patient_allergies_updated BEFORE UPDATE ON patient_allergies
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Row-level security — same pattern as every other tenant table
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    tbl TEXT;
+    tables TEXT[] := ARRAY['patient_conditions', 'patient_medications', 'patient_allergies'];
+BEGIN
+    FOREACH tbl IN ARRAY tables LOOP
+        EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', tbl);
+        EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', tbl);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I USING (org_id = app_current_org_id()) '
+            'WITH CHECK (org_id = app_current_org_id())',
+            'tenant_isolation_' || tbl, tbl
+        );
+    END LOOP;
+END
+$$;
+
+-- =============================================================================
+-- 007_clinical_detail.sql complete
+-- =============================================================================

--- a/server/src/fhir/resources/index.js
+++ b/server/src/fhir/resources/index.js
@@ -17,8 +17,29 @@
  */
 
 const { errors } = require('../../util/errors');
-const patientService = require('../../services/patientService');
-const labResultService = require('../../services/labResultService');
+const patientService    = require('../../services/patientService');
+const labResultService  = require('../../services/labResultService');
+const conditionService  = require('../../services/conditionService');
+const medicationService = require('../../services/medicationService');
+const allergyService    = require('../../services/allergyService');
+
+/**
+ * Resolve a FHIR subject/patient reference to a native patients row.
+ * Returns null if the patient cannot be found so postCreate hooks can
+ * gracefully skip native materialisation rather than throwing.
+ */
+async function resolveNativePatient(client, ctx, subjectRef) {
+  const fhirPatientId = (subjectRef || '').replace(/^Patient\//, '');
+  if (!fhirPatientId) return null;
+  const res = await client.query(
+    `SELECT body FROM fhir_resources
+     WHERE org_id = $1 AND resource_type = 'Patient' AND resource_id = $2`,
+    [ctx.orgId, fhirPatientId],
+  );
+  const mrn = res.rows[0]?.body?.identifier?.[0]?.value;
+  if (!mrn) return null;
+  return patientService.getByMrn(client, ctx, mrn);
+}
 
 function requireField(obj, path, label) {
   const segs = path.split('.');
@@ -122,12 +143,56 @@ const MedicationRequest = {
     expectType(body, 'MedicationRequest');
     if (!body.subject?.reference) throw errors.badRequest('subject.reference required');
   },
+  async postCreate(client, ctx, body) {
+    const native = await resolveNativePatient(client, ctx, body.subject?.reference);
+    if (!native) return;
+    const medCC  = body.medicationCodeableConcept;
+    const coding = medCC?.coding?.[0];
+    const dosage = (body.dosageInstruction || [])[0];
+    await medicationService.create(client, ctx, {
+      patient_id:       native.id,
+      medication_code:  coding?.code || null,
+      code_system:      coding?.system || null,
+      medication_name:  coding?.display || medCC?.text || 'Unknown medication',
+      status:           body.status || null,
+      intent:           body.intent || null,
+      dosage_text:      dosage?.text || null,
+      frequency:        dosage?.timing?.code?.text || null,
+      route:            dosage?.route?.coding?.[0]?.display || dosage?.route?.text || null,
+      authored_on:      body.authoredOn?.substring(0, 10) || null,
+      prescriber:       body.requester?.display || null,
+      source:           'FHIR_R4',
+      fhir_resource_id: body.id || null,
+    });
+  },
 };
 
 const AllergyIntolerance = {
   validate(body) {
     expectType(body, 'AllergyIntolerance');
     if (!body.patient?.reference) throw errors.badRequest('patient.reference required');
+  },
+  async postCreate(client, ctx, body) {
+    const native = await resolveNativePatient(client, ctx, body.patient?.reference);
+    if (!native) return;
+    const coding  = body.code?.coding?.[0];
+    const display = coding?.display || body.code?.text || 'Unknown allergen';
+    await allergyService.create(client, ctx, {
+      patient_id:           native.id,
+      code:                 coding?.code || null,
+      code_system:          coding?.system || null,
+      display,
+      allergy_type:         body.type || null,
+      category:             Array.isArray(body.category) ? body.category[0] : null,
+      criticality:          body.criticality || null,
+      clinical_status:      body.clinicalStatus?.coding?.[0]?.code || null,
+      verification_status:  body.verificationStatus?.coding?.[0]?.code || null,
+      reaction_description: body.reaction?.[0]?.description ||
+                            body.reaction?.[0]?.manifestation?.[0]?.text || null,
+      onset_date:           body.onsetDateTime?.substring(0, 10) || body.onsetDate || null,
+      source:               'FHIR_R4',
+      fhir_resource_id:     body.id || null,
+    });
   },
 };
 
@@ -157,6 +222,25 @@ const Condition = {
     if (!body.code?.coding?.length && !body.code?.text) {
       throw errors.badRequest('code.coding or code.text required');
     }
+  },
+  async postCreate(client, ctx, body) {
+    const native = await resolveNativePatient(client, ctx, body.subject?.reference);
+    if (!native) return;
+    const coding  = body.code?.coding?.[0];
+    const display = coding?.display || body.code?.text || 'Unknown condition';
+    await conditionService.create(client, ctx, {
+      patient_id:          native.id,
+      code:                coding?.code || display,
+      code_system:         coding?.system || null,
+      display,
+      clinical_status:     body.clinicalStatus?.coding?.[0]?.code || null,
+      verification_status: body.verificationStatus?.coding?.[0]?.code || null,
+      category:            body.category?.[0]?.coding?.[0]?.code || null,
+      onset_date:          body.onsetDateTime?.substring(0, 10) || body.onsetDate || null,
+      abatement_date:      body.abatementDateTime?.substring(0, 10) || body.abatementDate || null,
+      source:              'FHIR_R4',
+      fhir_resource_id:    body.id || null,
+    });
   },
 };
 

--- a/server/src/integrations/epic/importPatient.js
+++ b/server/src/integrations/epic/importPatient.js
@@ -22,22 +22,38 @@
  *   - FHIR resources are written to `fhir_resources` via fhir/storage.create.
  *     Resource ids are namespaced as `epic-<original-id>` to avoid colliding
  *     with native FHIR rows.
+ *   - Clinical resources are ALSO materialised into native structured tables:
+ *       Observation        → lab_results
+ *       Condition          → patient_conditions
+ *       MedicationRequest  → patient_medications
+ *       AllergyIntolerance → patient_allergies
  *   - One audit log entry per import call: action `integration.epic.import`.
  *
  * Returns:
  *   {
  *     patient,              // the TransTrack patients row (post-upsert)
  *     created,              // boolean - true if a new patient was inserted
- *     stored: {             // counts of FHIR resources persisted
+ *     stored: {             // counts of FHIR resources persisted (fhir_resources)
  *       observations, conditions, medicationRequests, allergies,
+ *     },
+ *     materialised: {       // counts written into native structured tables
+ *       labResults, conditions, medications, allergies,
  *     },
  *     scopeGranted,         // scope string from Epic, if available
  *   }
  */
 
-const patientService = require('../../services/patientService');
-const audit = require('../../services/auditService');
-const fhirStorage = require('../../fhir/storage');
+const patientService    = require('../../services/patientService');
+const labResultService  = require('../../services/labResultService');
+const conditionService  = require('../../services/conditionService');
+const medicationService = require('../../services/medicationService');
+const allergyService    = require('../../services/allergyService');
+const audit             = require('../../services/auditService');
+const fhirStorage       = require('../../fhir/storage');
+
+// ---------------------------------------------------------------------------
+// Patient normalisation helpers
+// ---------------------------------------------------------------------------
 
 function pickName(patient) {
   const n =
@@ -85,11 +101,11 @@ function pickEmail(patient) {
 
 function mapGender(g) {
   switch ((g || '').toLowerCase()) {
-    case 'male':   return 'M';
-    case 'female': return 'F';
-    case 'other':  return 'O';
+    case 'male':    return 'M';
+    case 'female':  return 'F';
+    case 'other':   return 'O';
     case 'unknown': return 'U';
-    default: return null;
+    default:        return null;
   }
 }
 
@@ -121,13 +137,13 @@ async function persistPatient(client, ctx, patient) {
   const existing = await patientService.getByMrn(client, ctx, native.mrn);
   if (existing) {
     const updated = await patientService.update(client, ctx, existing.id, {
-      first_name: native.first_name || existing.first_name,
-      last_name: native.last_name || existing.last_name,
-      middle_name: native.middle_name || existing.middle_name,
+      first_name:    native.first_name    || existing.first_name,
+      last_name:     native.last_name     || existing.last_name,
+      middle_name:   native.middle_name   || existing.middle_name,
       date_of_birth: native.date_of_birth || existing.date_of_birth,
-      sex: native.sex || existing.sex,
-      phone: native.phone || existing.phone,
-      email: native.email || existing.email,
+      sex:           native.sex           || existing.sex,
+      phone:         native.phone         || existing.phone,
+      email:         native.email         || existing.email,
     });
     return { row: updated || existing, created: false };
   }
@@ -135,16 +151,167 @@ async function persistPatient(client, ctx, patient) {
   return { row, created: true };
 }
 
-async function persistFhirCollection(client, ctx, type, resources) {
-  let n = 0;
-  for (const r of resources || []) {
-    if (!r || r.resourceType !== type) continue;
-    const namespacedId = r.id ? `epic-${r.id}` : undefined;
-    await fhirStorage.create(client, ctx, type, { ...r, id: namespacedId });
-    n += 1;
-  }
-  return n;
+// ---------------------------------------------------------------------------
+// Helpers — store to fhir_resources AND materialise into native tables
+// ---------------------------------------------------------------------------
+
+function namespacedId(resource) {
+  return resource?.id ? `epic-${resource.id}` : undefined;
 }
+
+async function storeToFhir(client, ctx, type, resource) {
+  const id = namespacedId(resource);
+  await fhirStorage.create(client, ctx, type, { ...resource, id });
+  return id;
+}
+
+/**
+ * Observations → fhir_resources + lab_results
+ */
+async function persistObservations(client, ctx, patientId, observations) {
+  let fhirStored = 0;
+  let nativeMaterialised = 0;
+
+  for (const obs of observations || []) {
+    if (!obs || obs.resourceType !== 'Observation') continue;
+    await storeToFhir(client, ctx, 'Observation', obs);
+    fhirStored++;
+
+    const coding = obs.code?.coding?.[0];
+    const value = obs.valueQuantity
+      ? `${obs.valueQuantity.value}`
+      : obs.valueString != null
+        ? obs.valueString
+        : obs.valueCodeableConcept?.text ?? null;
+
+    if (coding && value != null) {
+      await labResultService.create(client, ctx, {
+        patient_id:      patientId,
+        test_code:       coding.code,
+        test_name:       coding.display || coding.code,
+        value,
+        units:           obs.valueQuantity?.unit || null,
+        reference_range: (obs.referenceRange || [])[0]?.text || null,
+        result_status:   obs.status || null,
+        collected_at:    obs.effectiveDateTime || new Date().toISOString(),
+        resulted_at:     obs.issued || null,
+        source:          'FHIR_R4',
+      });
+      nativeMaterialised++;
+    }
+  }
+  return { fhirStored, nativeMaterialised };
+}
+
+/**
+ * Conditions → fhir_resources + patient_conditions
+ */
+async function persistConditions(client, ctx, patientId, conditions) {
+  let fhirStored = 0;
+  let nativeMaterialised = 0;
+
+  for (const cond of conditions || []) {
+    if (!cond || cond.resourceType !== 'Condition') continue;
+    const fhirId = await storeToFhir(client, ctx, 'Condition', cond);
+    fhirStored++;
+
+    const coding  = cond.code?.coding?.[0];
+    const display = coding?.display || cond.code?.text || 'Unknown condition';
+
+    await conditionService.create(client, ctx, {
+      patient_id:          patientId,
+      code:                coding?.code || display,
+      code_system:         coding?.system || null,
+      display,
+      clinical_status:     cond.clinicalStatus?.coding?.[0]?.code || null,
+      verification_status: cond.verificationStatus?.coding?.[0]?.code || null,
+      category:            cond.category?.[0]?.coding?.[0]?.code || null,
+      onset_date:          cond.onsetDateTime?.substring(0, 10) || cond.onsetDate || null,
+      abatement_date:      cond.abatementDateTime?.substring(0, 10) || cond.abatementDate || null,
+      source:              'FHIR_R4',
+      fhir_resource_id:    fhirId || null,
+    });
+    nativeMaterialised++;
+  }
+  return { fhirStored, nativeMaterialised };
+}
+
+/**
+ * MedicationRequests → fhir_resources + patient_medications
+ */
+async function persistMedicationRequests(client, ctx, patientId, medicationRequests) {
+  let fhirStored = 0;
+  let nativeMaterialised = 0;
+
+  for (const med of medicationRequests || []) {
+    if (!med || med.resourceType !== 'MedicationRequest') continue;
+    const fhirId = await storeToFhir(client, ctx, 'MedicationRequest', med);
+    fhirStored++;
+
+    const medCC  = med.medicationCodeableConcept;
+    const coding = medCC?.coding?.[0];
+    const medicationName = coding?.display || medCC?.text || 'Unknown medication';
+    const dosage = (med.dosageInstruction || [])[0];
+
+    await medicationService.create(client, ctx, {
+      patient_id:       patientId,
+      medication_code:  coding?.code || null,
+      code_system:      coding?.system || null,
+      medication_name:  medicationName,
+      status:           med.status || null,
+      intent:           med.intent || null,
+      dosage_text:      dosage?.text || null,
+      frequency:        dosage?.timing?.code?.text || null,
+      route:            dosage?.route?.coding?.[0]?.display || dosage?.route?.text || null,
+      authored_on:      med.authoredOn?.substring(0, 10) || null,
+      prescriber:       med.requester?.display || null,
+      source:           'FHIR_R4',
+      fhir_resource_id: fhirId || null,
+    });
+    nativeMaterialised++;
+  }
+  return { fhirStored, nativeMaterialised };
+}
+
+/**
+ * AllergyIntolerances → fhir_resources + patient_allergies
+ */
+async function persistAllergies(client, ctx, patientId, allergies) {
+  let fhirStored = 0;
+  let nativeMaterialised = 0;
+
+  for (const allergy of allergies || []) {
+    if (!allergy || allergy.resourceType !== 'AllergyIntolerance') continue;
+    const fhirId = await storeToFhir(client, ctx, 'AllergyIntolerance', allergy);
+    fhirStored++;
+
+    const coding  = allergy.code?.coding?.[0];
+    const display = coding?.display || allergy.code?.text || 'Unknown allergen';
+
+    await allergyService.create(client, ctx, {
+      patient_id:           patientId,
+      code:                 coding?.code || null,
+      code_system:          coding?.system || null,
+      display,
+      allergy_type:         allergy.type || null,
+      category:             Array.isArray(allergy.category) ? allergy.category[0] : null,
+      criticality:          allergy.criticality || null,
+      clinical_status:      allergy.clinicalStatus?.coding?.[0]?.code || null,
+      verification_status:  allergy.verificationStatus?.coding?.[0]?.code || null,
+      reaction_description: allergy.reaction?.[0]?.description ||
+                            allergy.reaction?.[0]?.manifestation?.[0]?.text || null,
+      onset_date:           allergy.onsetDateTime?.substring(0, 10) || allergy.onsetDate || null,
+      source:               'FHIR_R4',
+      fhir_resource_id:     fhirId || null,
+    });
+    nativeMaterialised++;
+  }
+  return { fhirStored, nativeMaterialised };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /**
  * Bundle mode - persist a pre-fetched Epic bundle.
@@ -153,43 +320,38 @@ async function importPatientFromBundle(client, ctx, bundle) {
   if (!bundle?.patient) {
     throw new Error('importPatientFromBundle: bundle.patient is required');
   }
-  const { row: patient, created } = await persistPatient(
-    client,
-    ctx,
-    bundle.patient,
-  );
+  const { row: patient, created } = await persistPatient(client, ctx, bundle.patient);
 
-  // Persist Patient FHIR resource as well so SMART/CDS clients can read it.
+  // Persist Patient FHIR resource so SMART/CDS clients can read it.
   const patientFhirId = `epic-${bundle.patient.id}`;
   await fhirStorage.create(client, ctx, 'Patient', {
     ...bundle.patient,
     id: patientFhirId,
     extension: [
       ...(bundle.patient.extension || []),
-      {
-        url: 'urn:transtrack:source-system',
-        valueString: 'epic-on-fhir-sandbox',
-      },
-      {
-        url: 'urn:transtrack:native-patient-id',
-        valueString: patient.id,
-      },
+      { url: 'urn:transtrack:source-system',    valueString: 'epic-on-fhir-sandbox' },
+      { url: 'urn:transtrack:native-patient-id', valueString: patient.id },
     ],
   });
 
+  const [obsResult, condResult, medResult, allergyResult] = await Promise.all([
+    persistObservations(client, ctx, patient.id, bundle.observations),
+    persistConditions(client, ctx, patient.id, bundle.conditions),
+    persistMedicationRequests(client, ctx, patient.id, bundle.medicationRequests),
+    persistAllergies(client, ctx, patient.id, bundle.allergies),
+  ]);
+
   const stored = {
-    observations: await persistFhirCollection(
-      client, ctx, 'Observation', bundle.observations,
-    ),
-    conditions: await persistFhirCollection(
-      client, ctx, 'Condition', bundle.conditions,
-    ),
-    medicationRequests: await persistFhirCollection(
-      client, ctx, 'MedicationRequest', bundle.medicationRequests,
-    ),
-    allergies: await persistFhirCollection(
-      client, ctx, 'AllergyIntolerance', bundle.allergies,
-    ),
+    observations:       obsResult.fhirStored,
+    conditions:         condResult.fhirStored,
+    medicationRequests: medResult.fhirStored,
+    allergies:          allergyResult.fhirStored,
+  };
+  const materialised = {
+    labResults:  obsResult.nativeMaterialised,
+    conditions:  condResult.nativeMaterialised,
+    medications: medResult.nativeMaterialised,
+    allergies:   allergyResult.nativeMaterialised,
   };
 
   await audit.record(client, ctx, {
@@ -202,17 +364,13 @@ async function importPatientFromBundle(client, ctx, bundle) {
       created,
       mrn: patient.mrn,
       stored,
+      materialised,
       scope_granted: bundle.scopeGranted || null,
       source: 'epic-on-fhir',
     },
   });
 
-  return {
-    patient,
-    created,
-    stored,
-    scopeGranted: bundle.scopeGranted || null,
-  };
+  return { patient, created, stored, materialised, scopeGranted: bundle.scopeGranted || null };
 }
 
 /**
@@ -235,4 +393,9 @@ module.exports = {
   pickName,
   importPatientFromBundle,
   importPatientFromEpic,
+  // exported for testing
+  persistObservations,
+  persistConditions,
+  persistMedicationRequests,
+  persistAllergies,
 };

--- a/server/src/services/allergyService.js
+++ b/server/src/services/allergyService.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const audit = require('./auditService');
+
+const COLS = [
+  'id', 'org_id', 'patient_id', 'code', 'code_system', 'display',
+  'allergy_type', 'category', 'criticality', 'clinical_status',
+  'verification_status', 'reaction_description', 'onset_date',
+  'notes', 'source', 'fhir_resource_id',
+  'created_at', 'updated_at',
+];
+
+async function listForPatient(client, ctx, patientId, { limit = 100 } = {}) {
+  const r = await client.query(
+    `SELECT ${COLS.join(',')} FROM patient_allergies
+     WHERE org_id = $1 AND patient_id = $2
+     ORDER BY criticality DESC NULLS LAST, created_at DESC
+     LIMIT $3`,
+    [ctx.orgId, patientId, limit],
+  );
+  return r.rows;
+}
+
+async function create(client, ctx, input) {
+  const cols = ['org_id'];
+  const vals = [ctx.orgId];
+  for (const k of Object.keys(input)) {
+    if (COLS.includes(k) && k !== 'id' && k !== 'org_id') {
+      cols.push(k);
+      vals.push(input[k]);
+    }
+  }
+  const ph = vals.map((_, i) => `$${i + 1}`).join(',');
+  const r = await client.query(
+    `INSERT INTO patient_allergies (${cols.join(',')}) VALUES (${ph})
+     RETURNING ${COLS.join(',')}`,
+    vals,
+  );
+  await audit.record(client, ctx, {
+    action: 'allergy.create',
+    entityType: 'patient_allergy',
+    entityId: r.rows[0].id,
+    details: {
+      display: r.rows[0].display,
+      criticality: r.rows[0].criticality,
+      source: r.rows[0].source,
+    },
+  });
+  return r.rows[0];
+}
+
+module.exports = { listForPatient, create, COLS };

--- a/server/src/services/conditionService.js
+++ b/server/src/services/conditionService.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const audit = require('./auditService');
+
+const COLS = [
+  'id', 'org_id', 'patient_id', 'code', 'code_system', 'display',
+  'clinical_status', 'verification_status', 'category',
+  'onset_date', 'abatement_date', 'notes', 'source', 'fhir_resource_id',
+  'created_at', 'updated_at',
+];
+
+async function listForPatient(client, ctx, patientId, { limit = 100, clinicalStatus } = {}) {
+  const params = [ctx.orgId, patientId];
+  let where = 'org_id = $1 AND patient_id = $2';
+  if (clinicalStatus) {
+    params.push(clinicalStatus);
+    where += ` AND clinical_status = $${params.length}`;
+  }
+  params.push(limit);
+  const r = await client.query(
+    `SELECT ${COLS.join(',')} FROM patient_conditions
+     WHERE ${where}
+     ORDER BY onset_date DESC NULLS LAST, created_at DESC
+     LIMIT $${params.length}`,
+    params,
+  );
+  return r.rows;
+}
+
+async function create(client, ctx, input) {
+  const cols = ['org_id'];
+  const vals = [ctx.orgId];
+  for (const k of Object.keys(input)) {
+    if (COLS.includes(k) && k !== 'id' && k !== 'org_id') {
+      cols.push(k);
+      vals.push(input[k]);
+    }
+  }
+  const ph = vals.map((_, i) => `$${i + 1}`).join(',');
+  const r = await client.query(
+    `INSERT INTO patient_conditions (${cols.join(',')}) VALUES (${ph})
+     RETURNING ${COLS.join(',')}`,
+    vals,
+  );
+  await audit.record(client, ctx, {
+    action: 'condition.create',
+    entityType: 'patient_condition',
+    entityId: r.rows[0].id,
+    details: {
+      code: r.rows[0].code,
+      display: r.rows[0].display,
+      source: r.rows[0].source,
+    },
+  });
+  return r.rows[0];
+}
+
+module.exports = { listForPatient, create, COLS };

--- a/server/src/services/medicationService.js
+++ b/server/src/services/medicationService.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const audit = require('./auditService');
+
+const COLS = [
+  'id', 'org_id', 'patient_id', 'medication_code', 'code_system',
+  'medication_name', 'status', 'intent', 'dosage_text', 'frequency',
+  'route', 'authored_on', 'prescriber', 'notes', 'source', 'fhir_resource_id',
+  'created_at', 'updated_at',
+];
+
+async function listForPatient(client, ctx, patientId, { limit = 100, status } = {}) {
+  const params = [ctx.orgId, patientId];
+  let where = 'org_id = $1 AND patient_id = $2';
+  if (status) {
+    params.push(status);
+    where += ` AND status = $${params.length}`;
+  }
+  params.push(limit);
+  const r = await client.query(
+    `SELECT ${COLS.join(',')} FROM patient_medications
+     WHERE ${where}
+     ORDER BY authored_on DESC NULLS LAST, created_at DESC
+     LIMIT $${params.length}`,
+    params,
+  );
+  return r.rows;
+}
+
+async function create(client, ctx, input) {
+  const cols = ['org_id'];
+  const vals = [ctx.orgId];
+  for (const k of Object.keys(input)) {
+    if (COLS.includes(k) && k !== 'id' && k !== 'org_id') {
+      cols.push(k);
+      vals.push(input[k]);
+    }
+  }
+  const ph = vals.map((_, i) => `$${i + 1}`).join(',');
+  const r = await client.query(
+    `INSERT INTO patient_medications (${cols.join(',')}) VALUES (${ph})
+     RETURNING ${COLS.join(',')}`,
+    vals,
+  );
+  await audit.record(client, ctx, {
+    action: 'medication.create',
+    entityType: 'patient_medication',
+    entityId: r.rows[0].id,
+    details: {
+      medication_name: r.rows[0].medication_name,
+      status: r.rows[0].status,
+      source: r.rows[0].source,
+    },
+  });
+  return r.rows[0];
+}
+
+module.exports = { listForPatient, create, COLS };

--- a/server/test/unit/epicIntegration.test.mjs
+++ b/server/test/unit/epicIntegration.test.mjs
@@ -162,6 +162,188 @@ describe('Epic FHIR client (FHIR fetch)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Clinical data materialisation
+// ---------------------------------------------------------------------------
+
+describe('Epic clinical data materialisation', () => {
+  const importer = (() => {
+    const req = createRequire(import.meta.url);
+    return req('../../src/integrations/epic/importPatient.js');
+  })();
+
+  function makeMockClient(insertedRows = {}) {
+    const queries = [];
+    const client = {
+      _queries: queries,
+      query: async (sql, params) => {
+        queries.push({ sql, params });
+        // simulate fhir_resources Patient lookup returning nothing by default
+        if (sql.includes('fhir_resources')) return { rows: [] };
+        const table = sql.match(/INSERT INTO (\w+)/)?.[1];
+        const defaultRow = insertedRows[table] || { id: 'generated-uuid', ...Object.fromEntries((params || []).map((v, i) => [`col${i}`, v])) };
+        return { rows: [defaultRow] };
+      },
+    };
+    return client;
+  }
+
+  const ctx = { orgId: 'org-1', userId: 'user-1' };
+  const patientId = 'native-patient-uuid';
+
+  it('persistObservations: stores to fhir_resources and creates lab_results for valued obs', async () => {
+    const observations = [
+      {
+        resourceType: 'Observation',
+        id: 'obs-1',
+        status: 'final',
+        code: { coding: [{ code: '2160-0', display: 'Creatinine [Mass/volume] in Serum or Plasma' }] },
+        subject: { reference: 'Patient/epic-pt-1' },
+        valueQuantity: { value: 1.2, unit: 'mg/dL' },
+        effectiveDateTime: '2026-05-01T10:00:00Z',
+        issued: '2026-05-01T12:00:00Z',
+        referenceRange: [{ text: '0.7-1.3' }],
+      },
+      {
+        resourceType: 'Observation',
+        id: 'obs-2',
+        status: 'final',
+        code: { coding: [{ code: 'panel' }] },
+        subject: { reference: 'Patient/epic-pt-1' },
+        // No value — should store to FHIR but not create lab_result
+      },
+    ];
+    const client = makeMockClient({ lab_results: { id: 'lr-1', test_code: '2160-0', source: 'FHIR_R4' } });
+    const result = await importer.persistObservations(client, ctx, patientId, observations);
+    expect(result.fhirStored).toBe(2);
+    expect(result.nativeMaterialised).toBe(1);
+    const labInserts = client._queries.filter(q => q.sql.includes('INSERT INTO lab_results'));
+    expect(labInserts).toHaveLength(1);
+    expect(labInserts[0].params).toContain('2160-0');
+    expect(labInserts[0].params).toContain('FHIR_R4');
+  });
+
+  it('persistConditions: stores to fhir_resources and creates patient_conditions', async () => {
+    const conditions = [
+      {
+        resourceType: 'Condition',
+        id: 'cond-1',
+        subject: { reference: 'Patient/epic-pt-1' },
+        code: {
+          coding: [{ code: 'N18.5', system: 'http://hl7.org/fhir/sid/icd-10-cm', display: 'Chronic kidney disease, stage 5' }],
+        },
+        clinicalStatus: { coding: [{ code: 'active' }] },
+        verificationStatus: { coding: [{ code: 'confirmed' }] },
+        category: [{ coding: [{ code: 'problem-list-item' }] }],
+        onsetDateTime: '2022-03-15T00:00:00Z',
+      },
+    ];
+    const client = makeMockClient({
+      patient_conditions: { id: 'cond-uuid', code: 'N18.5', source: 'FHIR_R4' },
+    });
+    const result = await importer.persistConditions(client, ctx, patientId, conditions);
+    expect(result.fhirStored).toBe(1);
+    expect(result.nativeMaterialised).toBe(1);
+    const condInserts = client._queries.filter(q => q.sql.includes('INSERT INTO patient_conditions'));
+    expect(condInserts).toHaveLength(1);
+    expect(condInserts[0].params).toContain('N18.5');
+    expect(condInserts[0].params).toContain('active');
+    expect(condInserts[0].params).toContain('FHIR_R4');
+    expect(condInserts[0].params).toContain('2022-03-15');
+  });
+
+  it('persistMedicationRequests: stores to fhir_resources and creates patient_medications', async () => {
+    const medicationRequests = [
+      {
+        resourceType: 'MedicationRequest',
+        id: 'med-1',
+        status: 'active',
+        intent: 'order',
+        subject: { reference: 'Patient/epic-pt-1' },
+        medicationCodeableConcept: {
+          coding: [{ code: '197361', system: 'http://www.nlm.nih.gov/research/umls/rxnorm', display: 'Tacrolimus 1 MG Oral Capsule' }],
+        },
+        authoredOn: '2026-04-01',
+        requester: { display: 'Dr. Smith' },
+        dosageInstruction: [{ text: '1 mg twice daily', route: { coding: [{ display: 'Oral' }] } }],
+      },
+    ];
+    const client = makeMockClient({
+      patient_medications: { id: 'med-uuid', medication_name: 'Tacrolimus 1 MG Oral Capsule', source: 'FHIR_R4' },
+    });
+    const result = await importer.persistMedicationRequests(client, ctx, patientId, medicationRequests);
+    expect(result.fhirStored).toBe(1);
+    expect(result.nativeMaterialised).toBe(1);
+    const medInserts = client._queries.filter(q => q.sql.includes('INSERT INTO patient_medications'));
+    expect(medInserts).toHaveLength(1);
+    expect(medInserts[0].params).toContain('Tacrolimus 1 MG Oral Capsule');
+    expect(medInserts[0].params).toContain('active');
+    expect(medInserts[0].params).toContain('Dr. Smith');
+    expect(medInserts[0].params).toContain('FHIR_R4');
+  });
+
+  it('persistAllergies: stores to fhir_resources and creates patient_allergies', async () => {
+    const allergies = [
+      {
+        resourceType: 'AllergyIntolerance',
+        id: 'allergy-1',
+        type: 'allergy',
+        category: ['medication'],
+        criticality: 'high',
+        patient: { reference: 'Patient/epic-pt-1' },
+        code: {
+          coding: [{ code: '7980', system: 'http://www.nlm.nih.gov/research/umls/rxnorm', display: 'Penicillin' }],
+        },
+        clinicalStatus: { coding: [{ code: 'active' }] },
+        verificationStatus: { coding: [{ code: 'confirmed' }] },
+        reaction: [{ description: 'Anaphylaxis' }],
+        onsetDateTime: '2010-06-01T00:00:00Z',
+      },
+    ];
+    const client = makeMockClient({
+      patient_allergies: { id: 'allergy-uuid', display: 'Penicillin', source: 'FHIR_R4' },
+    });
+    const result = await importer.persistAllergies(client, ctx, patientId, allergies);
+    expect(result.fhirStored).toBe(1);
+    expect(result.nativeMaterialised).toBe(1);
+    const allergyInserts = client._queries.filter(q => q.sql.includes('INSERT INTO patient_allergies'));
+    expect(allergyInserts).toHaveLength(1);
+    expect(allergyInserts[0].params).toContain('Penicillin');
+    expect(allergyInserts[0].params).toContain('high');
+    expect(allergyInserts[0].params).toContain('medication');
+    expect(allergyInserts[0].params).toContain('Anaphylaxis');
+    expect(allergyInserts[0].params).toContain('FHIR_R4');
+  });
+
+  it('skips resources with wrong resourceType without throwing', async () => {
+    const client = makeMockClient();
+    const r1 = await importer.persistConditions(client, ctx, patientId, [{ resourceType: 'Observation' }]);
+    const r2 = await importer.persistMedicationRequests(client, ctx, patientId, [null, undefined]);
+    const r3 = await importer.persistAllergies(client, ctx, patientId, []);
+    expect(r1.fhirStored).toBe(0);
+    expect(r2.fhirStored).toBe(0);
+    expect(r3.fhirStored).toBe(0);
+  });
+
+  it('persistConditions: uses code.text when coding array is absent', async () => {
+    const conditions = [
+      {
+        resourceType: 'Condition',
+        id: 'cond-text',
+        subject: { reference: 'Patient/p' },
+        code: { text: 'End-stage renal disease' },
+      },
+    ];
+    const client = makeMockClient({
+      patient_conditions: { id: 'c-uuid', code: 'End-stage renal disease', source: 'FHIR_R4' },
+    });
+    const result = await importer.persistConditions(client, ctx, patientId, conditions);
+    expect(result.nativeMaterialised).toBe(1);
+    const condInserts = client._queries.filter(q => q.sql.includes('INSERT INTO patient_conditions'));
+    expect(condInserts[0].params).toContain('End-stage renal disease');
+  });
+});
+
 describe('Epic patient normalization', () => {
   it('extracts MRN from a typed identifier and maps gender to TransTrack codes', () => {
     const patient = {


### PR DESCRIPTION
## Summary

- **Migration `007_clinical_detail.sql`**: adds `patient_conditions`, `patient_medications`, `patient_allergies` tables with org-scoped RLS, indexes, and `updated_at` triggers — same pattern as all existing clinical tables
- **3 new services** (`conditionService`, `medicationService`, `allergyService`): `create` + `listForPatient` with per-row audit logging, following the `labResultService` pattern exactly
- **`importPatient.js` rewrite**: Epic import now writes to `fhir_resources` AND materialises structured rows into all four native tables (`lab_results`, `patient_conditions`, `patient_medications`, `patient_allergies`) in a single import call; `materialised` counts added to return value and audit log entry
- **`fhir/resources/index.js`**: added `postCreate` hooks to `Condition`, `MedicationRequest`, and `AllergyIntolerance` so that resources written through the FHIR R4 API directly also materialise into native tables (mirrors the existing `Observation → lab_results` hook)

## Test plan

- [ ] All 15 unit tests pass (`npx vitest run test/unit/epicIntegration.test.mjs` from `server/`)
- [ ] 6 new tests cover: Observation with value/no-value branching, Condition with coding and code.text fallback, MedicationRequest full field mapping, AllergyIntolerance with reaction description, wrong resourceType skip, and empty arrays
- [ ] Apply migration `007_clinical_detail.sql` against a dev Postgres instance and verify tables + RLS policies are created
- [ ] Run a full Epic import smoke test and confirm `materialised` counts appear in the audit log
