### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/37](https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/37)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit restricted token scopes by default.

Best fix here (without changing functionality):  
- Insert at workflow root (after `on:` section, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- It resolves the CodeQL finding directly.
- It applies consistently to all jobs unless overridden later.
- Current jobs (checkout, setup-node, npm commands, artifact upload) do not require write access to repository contents, so `contents: read` is a safe least-privilege baseline.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
