### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/38](https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/38)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `on:` block, before `jobs:`) with least-privilege access.

Best fix here without changing functionality:
- Set:
  - `contents: read` (needed for `actions/checkout`)
  - `actions: read` (safe minimal read for actions metadata; optional but compatible)
- Do not grant write scopes since this workflow does not create releases, comment on PRs, or modify repo state.
- Keep all jobs unchanged otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
