### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/39](https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/security/code-scanning/39)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, immediately after the `on:` triggers (before `jobs:`), so it applies to all jobs (`build`, `e2e`, `build-windows`) unless overridden later.

Best minimal fix without changing behavior:
- Set `contents: read` as recommended by CodeQL.
- Because the workflow uploads artifacts (`actions/upload-artifact`), include `actions: write` so artifact upload remains permitted across jobs.
- Keep scope minimal and avoid granting broader write permissions (like `contents: write`) unless needed.

This change is confined to `.github/workflows/ci.yml` and requires no imports, methods, or additional files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
