### PR TITLE
fix: add least-privilege permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves CodeQL code scanning alerts #37, #38, and #39 (workflow does not contain permissions).

Adds an explicit permissions block at the workflow root, immediately after the on: triggers, so all jobs inherit restricted token scopes by default:

- contents: read — required for ctions/checkout
- ctions: write — required for ctions/upload-artifact (used in the uild and e2e jobs)

This supersedes draft PRs #138, #139, and #140 (which each proposed slightly different permission sets). PR #140 identified the need for ctions: write for artifact upload; this PR consolidates that into one clean fix.

Closes #138, closes #139, closes #140

Made with [Cursor](https://cursor.com)