### PR TITLE
ci: fix CodeQL job name to match required status check in ruleset

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,12 +16,14 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     strategy:
       fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
 
     steps:
       - name: Checkout repository
@@ -30,12 +32,12 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
           build-mode: none
           queries: +security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:javascript-typescript"
+          category: "/language:${{ matrix.language }}"
           upload: always


### PR DESCRIPTION
Restored matrix strategy so the job is named Analyze (javascript-typescript), matching the required status check in the main-protection ruleset. This was blocking all Dependabot PRs from merging.

Made with [Cursor](https://cursor.com)