### PR TITLE
fix(security): resolve production-readiness weaknesses (pentest Mediums, action-queue UI, CI gates, doc accuracy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             const fs = require('fs');
             const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8'));
             const total = summary.total;
-            const hardMin = 8;
+            const hardMin = 15;
             const target = 60;
             const lines = total.lines.pct;
             const branches = total.branches.pct;
@@ -98,6 +98,30 @@ jobs:
           name: sbom
           path: sbom.json
           retention-days: 90
+
+  server:
+    name: Server Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install server dependencies
+        run: npm ci
+        working-directory: server
+
+      - name: Lint server
+        run: npm run lint
+        working-directory: server
+
+      - name: Run server unit tests
+        run: npm test
+        working-directory: server
 
   e2e:
     name: Playwright E2E Tests

--- a/assets/sample-imports/patient-roster-template.csv
+++ b/assets/sample-imports/patient-roster-template.csv
@@ -1,0 +1,3 @@
+patient_id,first_name,last_name,date_of_birth,blood_type,organ_needed,medical_urgency,waitlist_status,date_added_to_waitlist,last_evaluation_date,meld_score,pra_percentage,phone,email,diagnosis,notes
+UNOS-000001,Jane,Example,1968-04-12,O+,kidney,high,active,2025-11-03,2026-05-20,,42,555-0100,jane.example@example.org,ESRD secondary to diabetes,Template row - replace with real data
+UNOS-000002,John,Sample,1975-09-30,A-,liver,medium,active,2026-01-15,2026-06-01,24,,555-0101,john.sample@example.org,NASH cirrhosis,Template row - replace with real data

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,15 +100,17 @@ TransTrack is an **offline-first, HIPAA-compliant Electron desktop application**
 | IPC Handlers | 25+ modules under `electron/ipc/handlers/` | Auth, entities, admin, MFA, barriers, aHHQ, labs, clinical, operations, organ-offer state machine, living-donor workflow, post-transplant follow-up, OPTN/SRTR exports, HL7, SIEM, calculators, predictions, inactivation-risk, etc. |
 | Services | 10+ | Inactivation Risk Engine v2 (`inactivationRiskEngine.cjs`), risk engine v1, barriers, aHHQ, labs, clock, access, recovery, compliance, reconciliation |
 | Database | `init.cjs`, `schema.cjs` (27 tables), `migrations.cjs` | Schema definitions, SQLCipher encryption, versioned migrations |
-| License | `manager.cjs`, `tiers.cjs` (no-op stubs) | The licensing/activation system has been removed; these files exist as compatibility shims that always report fully licensed |
+| License | `electron/license/` (`manager.cjs`, `verifier.cjs`, `storage.cjs`, `machineId.cjs`, `tiers.cjs`) | Ed25519-signed per-customer license files with a 30-day full-feature trial fallback; states: `trial`, `trial_expired`, `active`, `in_grace`, `invalid`. See `docs/LICENSING.md` |
 | Functions | `lib/` | Priority scoring, donor matching, FHIR import |
 
 ## Build Variants
 
-The 1.0 distribution ships as a single unrestricted build. There are no
-evaluation / enterprise variants, no watermark, no patient/user limits, and
-no license activation requirement. (See `docs/DUE_DILIGENCE.md` §6 for the
-full statement and the historical rationale.)
+The distribution ships as a single build. Feature availability is governed
+at runtime by the license file: with no license present the app runs a
+30-day full-feature trial, after which creation paths lock until a signed
+license is activated. Per-customer licenses encode tier, expiry,
+user/patient/install limits, and feature flags. See `docs/LICENSING.md`
+for the operator's guide.
 
 ## Technology Stack
 

--- a/docs/DUE_DILIGENCE.md
+++ b/docs/DUE_DILIGENCE.md
@@ -122,31 +122,38 @@ All renderer-to-main communication passes through a secure IPC bridge with conte
 
 ## 4. Regulatory Compliance
 
+> **Status terminology.** "Implemented (self-assessed)" means the control
+> exists in the shipping code and has been verified by the vendor's own
+> automated tests and review. Independent third-party assessment
+> (security audit / compliance attestation) has **not yet** been
+> performed; buyers should treat these rows as vendor claims pending
+> external validation.
+
 ### 4.1 HIPAA Technical Safeguards (45 CFR § 164.312)
 
 | Requirement | Status | Implementation |
 |---|---|---|
-| Access Control (§164.312(a)) | Compliant | RBAC with per-entity permission enforcement |
-| Audit Controls (§164.312(b)) | Compliant | Immutable audit logs with WHO/WHAT/WHEN/WHERE |
-| Integrity Controls (§164.312(c)) | Compliant | Database triggers prevent audit log modification |
-| Transmission Security (§164.312(e)) | N/A | Offline application — no data transmission |
-| Authentication (§164.312(d)) | Compliant | bcrypt password hashing, account lockout, session management |
+| Access Control (§164.312(a)) | Implemented (self-assessed) | RBAC with per-entity permission enforcement |
+| Audit Controls (§164.312(b)) | Implemented (self-assessed) | Immutable audit logs with WHO/WHAT/WHEN/WHERE |
+| Integrity Controls (§164.312(c)) | Implemented (self-assessed) | Database triggers prevent audit log modification |
+| Transmission Security (§164.312(e)) | N/A (desktop) / Implemented (server tier) | Desktop is offline; the optional server tier enforces TLS |
+| Authentication (§164.312(d)) | Implemented (self-assessed) | bcrypt password hashing, account lockout, session management |
 
 ### 4.2 FDA 21 CFR Part 11
 
 | Requirement | Status | Implementation |
 |---|---|---|
-| Electronic Signatures | Compliant | Password-based authentication for all operations |
-| Audit Trail | Compliant | Append-only audit logs capture all data changes |
-| Record Integrity | Compliant | SQLCipher encryption + HMAC integrity on license data |
+| Electronic Signatures | Implemented (self-assessed) | Password-based authentication for all operations |
+| Audit Trail | Implemented (self-assessed) | Append-only audit logs capture all data changes |
+| Record Integrity | Implemented (self-assessed) | SQLCipher encryption + HMAC integrity on license data |
 
 ### 4.3 AATB Standards
 
 | Requirement | Status | Implementation |
 |---|---|---|
-| Donor tracking | Compliant | Full donor lifecycle management with matching |
-| Traceability | Compliant | End-to-end audit trail from donor to recipient |
-| Data retention | Compliant | Configurable retention policies per organization |
+| Donor tracking | Implemented (self-assessed) | Full donor lifecycle management with matching |
+| Traceability | Implemented (self-assessed) | End-to-end audit trail from donor to recipient |
+| Data retention | Implemented (self-assessed) | Configurable retention policies per organization |
 
 ---
 
@@ -193,27 +200,25 @@ All renderer-to-main communication passes through a secure IPC bridge with conte
 
 ## 6. License & Distribution Model
 
-### 6.1 Current public release: open, no license keys
+### 6.1 Signed per-customer licenses with trial fallback
 
-The public **TransTrack 1.0** distribution ships with **all features unlocked
-and no activation requirement**. There are no tiers, license keys, evaluation
-windows, or paywalls in the publicly published binaries or source. This is
-consistent with the README and was a deliberate decision to maximise
-adoption inside transplant centers and OPOs without procurement friction.
+TransTrack ships with a cryptographic licensing system
+(`electron/license/`). Each customer receives a unique Ed25519-signed
+license file (`LIC1.` prefix) encoding organization, tier, expiry,
+user/patient/install limits, feature flags, and optional machine binding.
+With no license file present, the application runs a **30-day
+full-feature trial**, after which creation paths lock (reads remain
+available) until a license is activated.
 
-### 6.2 License modules are no-op stubs
+### 6.2 Runtime states
 
-`electron/license/manager.cjs` and `electron/license/tiers.cjs` are explicitly
-labelled "the licensing/activation system has been removed" and exist solely
-as compatibility shims so existing imports keep resolving. Every function in
-the module reports the application as fully licensed, every tier resolves to
-the same unlimited feature set, and there is no key validation, machine
-binding, HMAC seal, or expiration tracking present in the running code path.
-
-If a future OEM, enterprise, or distribution partner requires license
-gating, that work would be a deliberate re-introduction behind a build flag
-and would be released as a delta product. It is **not** present in the
-generally-available 1.0 build.
+The license manager (`electron/license/manager.cjs`) resolves one of five
+states at launch: `trial`, `trial_expired`, `active`, `in_grace`, or
+`invalid` (signature failure, machine mismatch, or expiry past grace).
+Signature verification, machine binding, and expiration tracking are
+enforced in the running code path. Operational procedures — issuing
+licenses, rotating the publisher keypair, handling verification failures —
+are documented in `docs/LICENSING.md`.
 
 ---
 
@@ -335,7 +340,7 @@ These items should be completed before first customer delivery:
 | Unauthorized data access | Low | RBAC + audit logging + org isolation |
 | Supply chain attack via dependencies | Low | Pinned versions, `npm audit` in CI, SBOM generation |
 | Data loss | Low | Single-file database, standard backup procedures |
-| License circumvention | N/A | The 1.0 build has no license enforcement; the modules under `electron/license/` are no-op stubs that always report fully licensed. |
+| License circumvention | Low | Ed25519 signature verification with optional machine binding; the private signing key is never distributed with the application. |
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -51,15 +51,17 @@ token, and the file in `userData` will not be written.
 
 ### Features Available
 
-TransTrack is fully featured out of the box — no license keys, activation,
-or tiers are required. Every install includes:
+New installs run a 30-day full-feature trial; a signed license file
+(provided with your purchase) unlocks continued use — see the License page
+under Administration. Features include:
 
-- Unlimited patients, donors, and users
-- FHIR R4 import/export
-- EHR integration and bidirectional sync
+- Patient, donor, and user management (limits per license tier)
+- FHIR R4 import and file export
+- EHR integration: read-only import from Epic (patient demographics,
+  observations); TransTrack does not write data back into the EHR
 - Full audit and compliance reporting
 - Advanced analytics and custom reports
-- Free software updates
+- Software updates per your license/maintenance terms
 
 ---
 

--- a/docs/VALIDATION_ARTIFACTS.md
+++ b/docs/VALIDATION_ARTIFACTS.md
@@ -5,11 +5,11 @@
 | Field | Value |
 |-------|-------|
 | Document ID | TT-VAL-001 |
-| Version | 1.0.0 |
-| Status | Approved |
+| Version | 1.0.1 |
+| Status | Vendor-approved template — site execution (IQ/OQ/PQ sign-off) pending |
 | Effective Date | 2026-01-24 |
 | Author | TransTrack Development Team |
-| Approved By | Quality Assurance |
+| Approved By | Vendor internal QA (customer/site countersignature pending) |
 
 ---
 

--- a/docs/security/engagements/2026-06-pentest-run/PENTEST_REPORT.md
+++ b/docs/security/engagements/2026-06-pentest-run/PENTEST_REPORT.md
@@ -1,0 +1,298 @@
+# TransTrack — Internal Penetration Test Report
+
+| Document control | |
+|---|---|
+| Document ID | TT-SEC-PT-2026-06-002 |
+| Engagement type | Internal grey-box penetration test |
+| Version under test | v1.2.0 — commit on `main` post-PR #166 |
+| Assessment window | 2026-06-26 |
+| Performed by | Automated security pipeline + source-code review |
+| Authorization | Repository owner — explicit pentest request |
+| Status | **COMPLETE** |
+
+> This engagement exercises the desktop IPC surface, optional Fastify server
+> tier, and supporting infrastructure against the scope defined in
+> `docs/security/PENETRATION_TEST_SCOPE.md`. It supplements the June 2026
+> internal assessment (`engagements/2026-06-internal/`) and is **not** a
+> substitute for a contracted third-party vendor engagement.
+
+---
+
+## 1. Executive summary
+
+TransTrack v1.2.0 was subjected to grey-box penetration testing combining
+automated security test execution, dependency auditing, and manual review of
+authentication, authorization, IPC, FHIR/SMART, HL7 MLLP, and encryption
+controls. **No Critical or High-severity exploitable vulnerabilities were
+confirmed.** Four Medium findings and three Low/Informational hardening items
+were identified on the optional server tier and thin-client deployment path.
+All desktop IPC isolation, audit immutability, MFA, and cross-organization
+controls tested successfully.
+
+---
+
+## 2. Methodology
+
+| Phase | Technique | Coverage |
+|---|---|---|
+| Scoping | `PENETRATION_TEST_SCOPE.md` §3.1–3.2 | Desktop + server |
+| Automated tests | `npm run test:security`, `test:compliance`, IPC/MFA/HL7 suites | Desktop |
+| Server tests | `npm test` in `server/` (76 Vitest cases) | API, FHIR, SMART, HL7 |
+| Dependency audit | `npm audit --omit=dev` | Production deps |
+| Grey-box review | Source analysis of auth, IPC, FHIR, MLLP, subscriptions | High-risk paths |
+| Threat model cross-check | `docs/THREAT_MODEL.md` | STRIDE alignment |
+
+**Out of scope for this run:** live network exploitation against a deployed
+Docker stack, Windows installer binary fuzzing, social engineering, and DoS
+against production infrastructure (per SOW §4).
+
+---
+
+## 3. Test execution summary
+
+| Suite | Result |
+|---|---|
+| `tests/cross-org-access.test.cjs` | **13/13 PASS** |
+| `tests/compliance.test.cjs` | **31/31 PASS** |
+| `tests/ipc-integration.test.cjs` | **26/26 PASS** |
+| `tests/mfa.test.cjs` | **11/11 PASS** |
+| `tests/hl7Ingest.test.cjs` | **6/6 PASS** |
+| `server/test/**` (Vitest) | **76/76 PASS** |
+| `npm audit --omit=dev` | **0 vulnerabilities** |
+
+---
+
+## 4. Controls verified (no issues found)
+
+- **Cross-organization isolation** — schema-level and IPC-level org scoping enforced; SQL injection attempts blocked.
+- **IPC authentication** — login, lockout, session expiry, WebContents-bound sessions.
+- **RBAC on PHI handlers** — entity CRUD, backup, restore, import require appropriate roles.
+- **Audit log immutability** — UPDATE/DELETE triggers block tampering.
+- **MFA** — TOTP RFC 6238 vectors, backup codes, encrypted secrets at rest.
+- **HL7 ingest isolation** — cross-org MRN matching denied.
+- **Electron hardening** — context isolation, CSP, navigation/popup blocking (compliance suite).
+- **JWT integrity** — signature, expiry, issuer validation (server unit tests).
+- **SMART scope enforcement** — resource/op mismatch denied (unit tests).
+- **Audit hash chain** — tamper detection (server unit tests).
+- **FHIR subscription SSRF** — private IP ranges blocked at DNS resolution.
+- **FHIR auth default** — `FHIR_REQUIRE_AUTH` defaults to `true`.
+
+---
+
+## 5. Findings
+
+### PT-2026-06-001 — Unauthenticated OAuth token introspection and revocation
+
+| Field | Value |
+|---|---|
+| **Severity** | Medium |
+| **CWE** | CWE-287 (Improper Authentication) |
+| **Component** | `server/src/routes/smart.js` — `/oauth2/introspect`, `/oauth2/revoke` |
+| **Status** | Remediated (2026-07) — both endpoints now require client authentication via `server/src/smart/clientAuth.js` (Basic, `client_secret_post`, or `private_key_jwt`); introspection returns token data only to the owning client, revocation only revokes the caller's own tokens. Covered by `server/test/unit/smartClientAuth.test.mjs` |
+
+**Description:** SMART OAuth introspection and revocation endpoints are
+marked `public: true` with no client-credential requirement. Any network
+client can probe whether opaque access tokens are active (revealing scope,
+client_id, subject) and can revoke arbitrary tokens if the raw token value
+is known or guessed.
+
+**Evidence:**
+
+```376:397:server/src/routes/smart.js
+  app.post('/oauth2/introspect',
+    { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
+    async (req) => {
+      const data = z.object({ token: z.string().min(1) }).parse(req.body || {});
+      const found = await tokens.lookupAccess(data.token);
+      // ... returns active, scope, client_id, sub
+    });
+
+  app.post('/oauth2/revoke',
+    { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
+```
+
+**Impact:** Token metadata disclosure; denial-of-service via revocation if an
+attacker obtains or leaks a bearer token. Rate limiting (30/min) reduces
+brute-force feasibility but does not replace client authentication per RFC 7662.
+
+**Remediation:** Require HTTP Basic or `client_id` + `client_secret` on
+introspect/revoke; return `{ active: false }` for all unauthenticated callers.
+
+---
+
+### PT-2026-06-002 — SMART backend-system tokens bypass role preHandlers
+
+| Field | Value |
+|---|---|
+| **Severity** | Medium |
+| **CWE** | CWE-863 (Incorrect Authorization) |
+| **Component** | `server/src/middleware/auth.js` — `requireRole()` |
+| **Status** | Remediated (2026-07) — `requireRole()` no longer short-circuits for `smart_system`/`smart_user` tokens; SMART tokens are denied on native role-gated API routes. Covered by `server/test/unit/authRoles.test.mjs` |
+
+**Description:** Tokens with role `smart_system` (backend-services, no user)
+short-circuit all `requireRole()` checks. Access control relies entirely on
+SMART scope parsing. A misconfigured client registration or overly broad
+`system/*.read` scope could reach admin-only REST routes that lack an
+additional `requireSmartScope` preHandler.
+
+**Evidence:**
+
+```85:90:server/src/middleware/auth.js
+function requireRole(...allowed) {
+  return async function (req) {
+    if (!req.auth) throw errors.unauthorized();
+    if (req.auth.role === 'smart_system') return;
+```
+
+**Impact:** Potential privilege escalation if SMART client scopes are
+misconfigured during dynamic registration.
+
+**Remediation:** Audit every non-FHIR route for explicit scope checks;
+deny `smart_system` on routes that are not FHIR/Bulk Data; add integration
+test asserting backend tokens cannot reach `/audit`, `/patients`, etc.
+
+---
+
+### PT-2026-06-003 — JWT access/refresh tokens stored in `localStorage`
+
+| Field | Value |
+|---|---|
+| **Severity** | Medium |
+| **CWE** | CWE-922 (Insecure Storage of Sensitive Information) |
+| **Component** | `src/api/remoteClient.js` |
+| **Status** | Remediated (2026-07) — refresh tokens now travel in an `httpOnly` cookie set by the server (`server/src/auth/sessionCookies.js`); access tokens are held in renderer memory only; legacy `localStorage` keys are purged on load |
+
+**Description:** When the renderer operates in thin-client mode
+(`VITE_TRANSTRACK_API_URL`), bearer and refresh tokens persist in
+`localStorage`, which is readable by any same-origin JavaScript including
+XSS payloads.
+
+**Evidence:**
+
+```18:34:src/api/remoteClient.js
+const ACCESS_KEY = 'transtrack:access';
+const REFRESH_KEY = 'transtrack:refresh';
+// ...
+set: (access, refresh) => {
+  if (typeof localStorage === 'undefined') return;
+  if (access) localStorage.setItem(ACCESS_KEY, access);
+```
+
+**Impact:** XSS in the web/thin-client build could exfiltrate session tokens
+and access PHI via the REST API.
+
+**Remediation:** Prefer `httpOnly` Secure cookies for refresh tokens; store
+access tokens in memory only; tighten CSP on any web deployment.
+
+---
+
+### PT-2026-06-004 — HL7 MLLP plaintext mode enabled in dev Docker stack
+
+| Field | Value |
+|---|---|
+| **Severity** | Low |
+| **CWE** | CWE-319 (Cleartext Transmission) |
+| **Component** | `docker/docker-compose.yml`, `server/src/hl7/server.js` |
+| **Status** | Accepted (dev-only) |
+
+**Description:** Docker Compose sets `HL7_MLLP_TLS_CERT_FILE=""`, enabling
+plaintext MLLP on port 2575. Production warns when TLS is absent but does
+not hard-fail startup.
+
+**Impact:** PHI-bearing HL7 messages observable on the network if production
+is deployed without TLS certificates.
+
+**Remediation:** Fail closed in `NODE_ENV=production` when TLS cert paths are
+empty; document mandatory mTLS in deployment guide.
+
+---
+
+### PT-2026-06-005 — Hardcoded dev JWT secret in Docker Compose
+
+| Field | Value |
+|---|---|
+| **Severity** | Low |
+| **CWE** | CWE-798 (Hard-coded Credentials) |
+| **Component** | `docker/docker-compose.yml` |
+| **Status** | Accepted (dev-only) |
+
+**Description:** `JWT_SECRET: dev-jwt-secret-change-me-...` is committed for
+local integration testing.
+
+**Impact:** None if confined to developer workstations; critical if the same
+compose file is used unmodified in any shared/staging environment.
+
+**Remediation:** Require `.env` override with `:?` syntax so compose fails
+without an explicit secret outside local dev.
+
+---
+
+### PT-2026-06-006 — Browser dev mock client grants admin without authentication
+
+| Field | Value |
+|---|---|
+| **Severity** | Informational |
+| **CWE** | CWE-1188 (Insecure Default Initialization) |
+| **Component** | `src/api/localClient.js` — `mockClient` |
+| **Status** | Remediated (2026-07) — production builds now fail loudly via a guard proxy in `src/api/localClient.js` when the Electron bridge is unavailable; the mock client is reachable only in dev builds and test environments |
+
+**Description:** Vite hot-reload browser mode uses a mock client that
+auto-authenticates as `admin@transtrack.local`. Not included in Electron
+production builds.
+
+**Remediation:** Gate behind `import.meta.env.DEV` assertion; add build-time
+strip verification.
+
+---
+
+### PT-2026-06-007 — FHIR subscription SSRF DNS rebinding window
+
+| Field | Value |
+|---|---|
+| **Severity** | Low |
+| **CWE** | CWE-918 (SSRF) |
+| **Component** | `server/src/fhir/subscriptions.js` |
+| **Status** | Open |
+
+**Description:** Private-IP blocking occurs at DNS resolution time before the
+HTTP request. A DNS rebinding attack could theoretically pass validation
+then resolve to a private address at connection time.
+
+**Impact:** Limited — requires attacker-controlled subscription endpoint and
+timing; mitigations partially present.
+
+**Remediation:** Re-resolve and re-validate IP immediately before `http.request`;
+prefer allowlisted subscriber URLs for production tenants.
+
+---
+
+## 6. Risk summary
+
+| Severity | Count | IDs |
+|---|---|---|
+| Critical | 0 | — |
+| High | 0 | — |
+| Medium | 3 | PT-2026-06-001, 002, 003 |
+| Low | 3 | PT-2026-06-004, 005, 007 |
+| Informational | 1 | PT-2026-06-006 |
+
+---
+
+## 7. Recommendations
+
+1. **Remediate Medium findings** before enabling the server tier in any
+   customer-facing or internet-exposed deployment.
+2. **Procure third-party pentest** per `PENETRATION_TEST_SCOPE.md` — this
+   internal run does not satisfy pre-commercial-release item B4.
+3. **Re-test** OAuth/SMART endpoints and thin-client token storage after fixes.
+4. **Populate** `PENTEST_REMEDIATION_TRACKER.md` with rows for PT-2026-06-001
+   through PT-2026-06-007.
+
+---
+
+## 8. Sign-off
+
+| Role | Name | Date |
+|---|---|---|
+| Assessment lead | TransTrack Engineering (automated + review) | 2026-06-26 |
+| Next engagement | Third-party vendor per `PENTEST_VENDOR_CHECKLIST.md` | Pending |

--- a/marketing/demo.html
+++ b/marketing/demo.html
@@ -1,0 +1,1127 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TransTrack — Demo</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #f0f5fb;
+        --bg-2: #e4ecf6;
+        --panel: #ffffff;
+        --panel-2: #f7fafd;
+        --border: rgba(30, 80, 160, 0.14);
+        --text: #0d1f38;
+        --muted: #3a5a82;
+        --accent: #0284c7;
+        --accent-2: #0891b2;
+        --warn: #d97706;
+        --good: #059669;
+        --bad: #dc2626;
+        --grad: linear-gradient(135deg, #0284c7 0%, #0891b2 50%, #059669 100%);
+        --grad-soft: linear-gradient(180deg, rgba(2,132,199,.08), rgba(2,132,199,0));
+      }
+
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+
+      body {
+        background: #c8d8ee;
+        font-family: 'Inter', system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        overflow: hidden;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      /* ── STAGE ── */
+      #stage {
+        position: relative;
+        width: 1280px;
+        height: 720px;
+        background: var(--bg);
+        overflow: hidden;
+        border-radius: 12px;
+        box-shadow: 0 0 80px rgba(2, 132, 199, 0.18);
+      }
+
+      /* ambient glow blobs */
+      .glow-a {
+        position: absolute;
+        width: 900px; height: 900px;
+        top: -350px; right: -300px;
+        background: radial-gradient(closest-side, rgba(2,132,199,.10), transparent 70%);
+        filter: blur(30px);
+        pointer-events: none;
+      }
+      .glow-b {
+        position: absolute;
+        width: 700px; height: 700px;
+        bottom: -350px; left: -200px;
+        background: radial-gradient(closest-side, rgba(5,150,105,.08), transparent 70%);
+        filter: blur(30px);
+        pointer-events: none;
+      }
+
+      /* ── PROGRESS BAR ── */
+      #progress-bar {
+        position: absolute;
+        bottom: 0; left: 0; right: 0;
+        height: 3px;
+        background: rgba(255,255,255,.06);
+        z-index: 100;
+      }
+      #progress-fill {
+        height: 100%;
+        background: var(--grad);
+        transition: width 0.1s linear;
+        width: 0%;
+      }
+
+      /* ── CONTROLS ── */
+      #controls {
+        position: absolute;
+        bottom: 14px;
+        right: 20px;
+        display: flex;
+        gap: 10px;
+        z-index: 100;
+      }
+      .ctrl-btn {
+        width: 34px; height: 34px;
+        border-radius: 8px;
+        background: rgba(255,255,255,.8);
+        border: 1px solid var(--border);
+        color: var(--text);
+        cursor: pointer;
+        display: grid; place-items: center;
+        font-size: 14px;
+        transition: background .15s;
+        backdrop-filter: blur(6px);
+      }
+      .ctrl-btn:hover { background: #fff; }
+
+      /* scene indicator */
+      #dots {
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 7px;
+        z-index: 100;
+      }
+      .dot {
+        width: 6px; height: 6px;
+        border-radius: 50%;
+        background: rgba(255,255,255,.2);
+        transition: background .3s, transform .3s;
+      }
+      .dot.active {
+        background: var(--accent);
+        transform: scale(1.4);
+      }
+
+      /* ── SCENES ── */
+      .scene {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity .5s ease;
+      }
+      .scene.active {
+        opacity: 1;
+        pointer-events: all;
+      }
+
+      /* shared text helpers */
+      .eyebrow {
+        display: inline-flex; align-items: center; gap: 8px;
+        padding: 5px 12px;
+        border: 1px solid rgba(2,132,199,.3);
+        border-radius: 999px;
+        background: rgba(2,132,199,.1);
+        color: #0369a1;
+        font-size: 12px; font-weight: 700; letter-spacing: .5px;
+        text-transform: uppercase;
+        margin-bottom: 16px;
+      }
+      .eyebrow .pulse {
+        width: 7px; height: 7px;
+        border-radius: 50%;
+        background: #34d399;
+        box-shadow: 0 0 0 4px rgba(52,211,153,.2);
+        animation: pulse-ring 1.8s ease-out infinite;
+      }
+      @keyframes pulse-ring {
+        0%   { box-shadow: 0 0 0 0 rgba(52,211,153,.5); }
+        70%  { box-shadow: 0 0 0 7px rgba(52,211,153,0); }
+        100% { box-shadow: 0 0 0 0 rgba(52,211,153,0); }
+      }
+
+      .grad-text {
+        background: var(--grad);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 1 — Title card
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s1 {
+        flex-direction: column;
+        text-align: center;
+        gap: 0;
+        padding: 60px;
+      }
+      #s1 .logo {
+        display: flex; align-items: center; gap: 14px;
+        margin-bottom: 32px;
+      }
+      #s1 .mark {
+        width: 56px; height: 56px;
+        border-radius: 14px;
+        background: var(--grad);
+        display: grid; place-items: center;
+        font-size: 22px; font-weight: 900;
+        color: #002233;
+        flex-shrink: 0;
+      }
+      #s1 .brand-name {
+        font-size: 42px; font-weight: 900;
+        letter-spacing: -.02em;
+        color: var(--text);
+      }
+      #s1 h1 {
+        font-size: 52px; font-weight: 900; line-height: 1.05;
+        letter-spacing: -.03em;
+        max-width: 860px;
+        animation: fadeup .7s ease both;
+      }
+      #s1 .sub {
+        color: var(--muted);
+        font-size: 20px;
+        margin-top: 16px;
+        max-width: 680px;
+        animation: fadeup .7s .2s ease both;
+      }
+      #s1 .chips {
+        display: flex; gap: 12px; margin-top: 32px;
+        animation: fadeup .7s .4s ease both;
+      }
+      .chip {
+        padding: 8px 16px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        font-size: 13px; font-weight: 600;
+        color: var(--muted);
+        background: rgba(255,255,255,.7);
+      }
+      .chip.hi { border-color: rgba(5,150,105,.4); color: #065f46; background: rgba(5,150,105,.1); }
+
+      @keyframes fadeup {
+        from { opacity:0; transform: translateY(20px); }
+        to   { opacity:1; transform: translateY(0); }
+      }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 2 — Problem
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s2 { flex-direction: column; padding: 60px 80px; gap: 36px; }
+      #s2 h2 {
+        font-size: 40px; font-weight: 900; line-height: 1.08;
+        letter-spacing: -.02em; text-align: center;
+      }
+      .prob-cards {
+        display: grid; grid-template-columns: repeat(3,1fr); gap: 16px;
+        width: 100%;
+      }
+      .prob-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 22px;
+        opacity: 0;
+        transform: translateY(18px);
+        transition: opacity .5s ease, transform .5s ease;
+        box-shadow: 0 2px 12px rgba(13,31,56,.07);
+      }
+      .prob-card.in { opacity: 1; transform: none; }
+      .prob-icon {
+        width: 40px; height: 40px;
+        border-radius: 10px;
+        background: rgba(220,38,38,.1);
+        border: 1px solid rgba(220,38,38,.25);
+        color: #b91c1c;
+        display: grid; place-items: center;
+        font-size: 18px; margin-bottom: 12px;
+      }
+      .prob-card h3 { font-size: 16px; margin-bottom: 6px; color: var(--text); }
+      .prob-card p { font-size: 13px; color: var(--muted); line-height: 1.5; }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 3 — Risk Dashboard overview
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s3 { padding: 40px 56px; flex-direction: column; align-items: flex-start; gap: 20px; }
+      #s3 .dash-head {
+        display: flex; justify-content: space-between; align-items: center;
+        width: 100%;
+      }
+      #s3 .dash-head h2 { font-size: 22px; font-weight: 800; }
+      .kpi-row {
+        display: grid; grid-template-columns: repeat(4,1fr); gap: 14px; width: 100%;
+      }
+      .kpi {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 18px;
+        opacity: 0; transform: translateY(14px);
+        transition: opacity .4s ease, transform .4s ease;
+        box-shadow: 0 2px 10px rgba(13,31,56,.06);
+      }
+      .kpi.in { opacity: 1; transform: none; }
+      .kpi .k-lbl { font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); font-weight: 600; }
+      .kpi .k-val { font-size: 32px; font-weight: 900; margin: 4px 0 2px; }
+      .kpi .k-sub { font-size: 12px; color: var(--muted); }
+      .kpi.red .k-val { color: #dc2626; }
+      .kpi.warn .k-val { color: #d97706; }
+      .kpi.good .k-val { color: #059669; }
+      .kpi.blue .k-val { color: #0284c7; }
+
+      .patient-list {
+        width: 100%;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        overflow: hidden;
+        opacity: 0; transform: translateY(14px);
+        transition: opacity .5s .3s ease, transform .5s .3s ease;
+        box-shadow: 0 2px 10px rgba(13,31,56,.06);
+      }
+      .patient-list.in { opacity: 1; transform: none; }
+      .pt-header {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr 1.5fr 1fr;
+        padding: 10px 16px;
+        background: var(--bg-2);
+        border-bottom: 1px solid var(--border);
+        font-size: 11px; font-weight: 700;
+        text-transform: uppercase; letter-spacing: .5px;
+        color: var(--muted);
+      }
+      .pt-row {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr 1.5fr 1fr;
+        padding: 11px 16px;
+        border-bottom: 1px solid var(--border);
+        font-size: 13px;
+        align-items: center;
+        color: var(--text);
+        opacity: 0;
+        transition: opacity .35s ease, background .2s;
+      }
+      .pt-row:last-child { border-bottom: none; }
+      .pt-row.in { opacity: 1; }
+      .pt-row:hover { background: var(--bg); }
+      .risk-pill {
+        display: inline-flex; align-items: center; gap: 5px;
+        padding: 3px 9px; border-radius: 999px; font-size: 11px; font-weight: 700;
+      }
+      .risk-high   { background: rgba(220,38,38,.12); color: #991b1b; border: 1px solid rgba(220,38,38,.3); }
+      .risk-mod    { background: rgba(217,119,6,.12); color: #92400e; border: 1px solid rgba(217,119,6,.3); }
+      .risk-low    { background: rgba(5,150,105,.1); color: #065f46; border: 1px solid rgba(5,150,105,.3); }
+      .score-num   { font-weight: 800; font-family: 'JetBrains Mono', monospace; }
+      .pt-factor   { font-size: 12px; color: var(--muted); }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 4 — Risk Card detail
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s4 { padding: 40px 56px; gap: 28px; align-items: flex-start; }
+      .risk-card {
+        flex: 1;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 24px;
+        display: flex; flex-direction: column; gap: 14px;
+        box-shadow: 0 2px 14px rgba(13,31,56,.07);
+      }
+      .risk-card-head {
+        display: flex; justify-content: space-between; align-items: center;
+      }
+      .risk-card-head .title { font-weight: 800; font-size: 15px; }
+      .risk-card-head .badge-high {
+        padding: 4px 12px;
+        border-radius: 999px;
+        background: rgba(220,38,38,.12);
+        color: #991b1b;
+        border: 1px solid rgba(220,38,38,.3);
+        font-size: 12px; font-weight: 700;
+      }
+      .prob-row {
+        display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px;
+      }
+      .prob-stat {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 12px;
+      }
+      .prob-stat .ps-lbl { font-size: 10px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); font-weight: 600; }
+      .prob-stat .ps-val { font-size: 26px; font-weight: 900; margin-top: 2px; color: var(--text); }
+      .prob-stat .ps-bar {
+        height: 5px; border-radius: 999px; background: rgba(13,31,56,.1); margin-top: 8px; overflow: hidden;
+      }
+      .prob-stat .ps-bar span {
+        display: block; height: 100%; background: var(--grad); border-radius: 999px;
+        width: 0; transition: width 1.2s ease;
+      }
+      .factor-section h4 { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 10px; font-weight: 700; }
+      .factor-item {
+        display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
+        font-size: 13px; margin-bottom: 8px;
+      }
+      .factor-item .fi-name { color: var(--text); }
+      .factor-item .fi-pct { font-weight: 700; font-family: 'JetBrains Mono', monospace; color: #dc2626; }
+      .fi-bar-wrap { grid-column: 1/-1; height: 5px; background: rgba(13,31,56,.1); border-radius: 999px; overflow: hidden; }
+      .fi-bar-fill {
+        height: 100%; border-radius: 999px;
+        background: linear-gradient(90deg, #d97706, #dc2626);
+        width: 0; transition: width 1s ease;
+      }
+
+      .risk-right {
+        width: 340px; display: flex; flex-direction: column; gap: 16px;
+      }
+      .ctf-box {
+        background: rgba(5,150,105,.07);
+        border: 1px solid rgba(5,150,105,.3);
+        border-radius: 14px;
+        padding: 18px;
+      }
+      .ctf-box .ctf-label {
+        font-size: 11px; text-transform: uppercase; letter-spacing: .5px;
+        color: #065f46; font-weight: 700; margin-bottom: 8px;
+      }
+      .ctf-box .ctf-body { font-size: 13px; color: var(--text); line-height: 1.6; }
+      .ctf-box .ctf-body strong { color: #047857; }
+      .score-change {
+        display: flex; align-items: center; gap: 10px; margin-top: 12px;
+      }
+      .score-bubble {
+        width: 54px; height: 54px; border-radius: 50%;
+        display: grid; place-items: center;
+        font-size: 18px; font-weight: 900;
+      }
+      .sb-red { background: rgba(220,38,38,.12); border: 2px solid rgba(220,38,38,.4); color: #991b1b; }
+      .sb-green { background: rgba(5,150,105,.12); border: 2px solid rgba(5,150,105,.4); color: #065f46; }
+      .score-arrow { font-size: 18px; color: var(--muted); }
+
+      .action-list .al-title {
+        font-size: 11px; text-transform: uppercase; letter-spacing: .5px;
+        color: var(--muted); font-weight: 700; margin-bottom: 10px;
+      }
+      .action-item {
+        display: flex; align-items: center; gap: 10px;
+        padding: 10px 12px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        margin-bottom: 8px;
+        font-size: 13px;
+        box-shadow: 0 1px 4px rgba(13,31,56,.06);
+        opacity: 0; transform: translateX(12px);
+        transition: opacity .4s ease, transform .4s ease;
+      }
+      .action-item.in { opacity: 1; transform: none; }
+      .action-rank {
+        width: 22px; height: 22px; border-radius: 6px;
+        background: var(--grad);
+        color: #fff; font-size: 11px; font-weight: 800;
+        display: grid; place-items: center; flex-shrink: 0;
+      }
+      .action-text { flex: 1; color: var(--text); }
+      .action-delta { font-size: 12px; font-weight: 700; color: #059669; font-family: 'JetBrains Mono', monospace; }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 5 — Transplant Clock
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s5 { flex-direction: column; padding: 48px 72px; gap: 28px; }
+      #s5 .clk-title { text-align: center; }
+      #s5 .clk-title h2 { font-size: 38px; font-weight: 900; letter-spacing: -.02em; margin-top: 8px; }
+      .clk-layout { display: grid; grid-template-columns: 240px 1fr; gap: 28px; width: 100%; align-items: center; }
+      .clk-face {
+        width: 200px; height: 200px;
+        border-radius: 50%;
+        background: var(--panel);
+        border: 2px solid var(--border);
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        position: relative;
+        margin: 0 auto;
+        box-shadow: 0 4px 30px rgba(2,132,199,.15);
+      }
+      .clk-face::before {
+        content: '';
+        position: absolute; inset: -8px;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        background: var(--grad) border-box;
+        -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+        -webkit-mask-composite: destination-out;
+        mask-composite: exclude;
+        animation: spin-border 4s linear infinite;
+      }
+      @keyframes spin-border {
+        from { transform: rotate(0deg); }
+        to   { transform: rotate(360deg); }
+      }
+      .clk-hz { font-size: 36px; font-weight: 900; color: #0284c7; font-family: 'JetBrains Mono', monospace; }
+      .clk-unit { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .6px; font-weight: 600; }
+      .clk-label { font-size: 11px; color: var(--muted); margin-top: 4px; font-weight: 500; }
+      .clk-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+      .clk-metric {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 14px;
+        box-shadow: 0 1px 6px rgba(13,31,56,.06);
+        opacity: 0; transform: translateY(10px);
+        transition: opacity .4s ease, transform .4s ease;
+      }
+      .clk-metric.in { opacity: 1; transform: none; }
+      .clk-metric .cm-lbl { font-size: 11px; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); font-weight: 600; }
+      .clk-metric .cm-val { font-size: 22px; font-weight: 800; margin-top: 4px; }
+      .clk-metric.red .cm-val { color: #dc2626; }
+      .clk-metric.warn .cm-val { color: #d97706; }
+      .clk-metric.good .cm-val { color: #059669; }
+      .clk-metric.blue .cm-val { color: #0284c7; }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 6 — Differentiators
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s6 { flex-direction: column; padding: 40px 64px; gap: 24px; }
+      #s6 .diff-intro { text-align: center; }
+      #s6 .diff-intro h2 { font-size: 34px; font-weight: 900; letter-spacing: -.02em; margin-top: 6px; }
+      .diff-grid {
+        display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; width: 100%;
+      }
+      .diff-card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 18px;
+        box-shadow: 0 2px 10px rgba(13,31,56,.06);
+        opacity: 0; transform: translateY(14px);
+        transition: opacity .4s ease, transform .4s ease;
+        position: relative; overflow: hidden;
+      }
+      .diff-card::before {
+        content: '';
+        position: absolute; inset: 0;
+        background: radial-gradient(400px 160px at 0% 0%, rgba(2,132,199,.05), transparent 60%);
+        pointer-events: none;
+      }
+      .diff-card.in { opacity: 1; transform: none; }
+      .diff-num { font-size: 28px; font-weight: 900; color: rgba(2,132,199,.25); margin-bottom: 8px; font-family: 'JetBrains Mono', monospace; }
+      .diff-card h3 { font-size: 14px; font-weight: 700; margin-bottom: 6px; color: var(--text); }
+      .diff-card p { font-size: 12px; color: var(--muted); line-height: 1.5; }
+      .diff-tag {
+        position: absolute; top: 14px; right: 14px;
+        font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .5px;
+        color: #059669;
+      }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 7 — Security / Compliance
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s7 { flex-direction: column; padding: 56px 80px; gap: 32px; text-align: center; }
+      #s7 h2 { font-size: 38px; font-weight: 900; letter-spacing: -.02em; }
+      .compliance-row {
+        display: grid; grid-template-columns: repeat(4,1fr); gap: 16px; width: 100%;
+      }
+      .comp-badge {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 22px 14px;
+        box-shadow: 0 2px 10px rgba(13,31,56,.06);
+        opacity: 0; transform: scale(.92);
+        transition: opacity .4s ease, transform .4s ease;
+      }
+      .comp-badge.in { opacity: 1; transform: none; }
+      .comp-badge .cb-icon { font-size: 28px; margin-bottom: 10px; }
+      .comp-badge .cb-h { font-size: 15px; font-weight: 700; color: var(--text); }
+      .comp-badge .cb-s { font-size: 12px; color: var(--muted); margin-top: 4px; }
+      .security-row {
+        display: flex; gap: 16px; width: 100%; justify-content: center;
+      }
+      .sec-item {
+        display: flex; align-items: center; gap: 10px;
+        padding: 10px 18px;
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        font-size: 13px; font-weight: 600;
+        color: var(--text);
+        box-shadow: 0 1px 4px rgba(13,31,56,.06);
+        opacity: 0;
+        transition: opacity .4s ease;
+      }
+      .sec-item.in { opacity: 1; }
+      .sec-item .si-dot { width: 8px; height: 8px; border-radius: 50%; background: #059669; }
+
+      /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+         SCENE 8 — CTA
+      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+      #s8 { flex-direction: column; text-align: center; gap: 10px; padding: 60px; }
+      #s8 .cta-logo {
+        display: flex; align-items: center; gap: 14px;
+        justify-content: center; margin-bottom: 16px;
+      }
+      #s8 .cta-mark {
+        width: 64px; height: 64px; border-radius: 16px;
+        background: var(--grad);
+        display: grid; place-items: center;
+        font-size: 26px; font-weight: 900; color: #002233;
+      }
+      #s8 .cta-name { font-size: 48px; font-weight: 900; letter-spacing: -.02em; }
+      #s8 h2 { font-size: 34px; font-weight: 900; letter-spacing: -.02em; margin-top: 4px; }
+      #s8 .cta-sub { color: var(--muted); font-size: 18px; max-width: 680px; margin: 10px auto 0; }
+      .cta-buttons { display: flex; gap: 14px; margin-top: 28px; justify-content: center; }
+      .cta-btn {
+        padding: 14px 28px; border-radius: 12px;
+        font-size: 15px; font-weight: 700; cursor: pointer;
+        border: none; text-decoration: none;
+      }
+      .cta-btn-primary { background: var(--grad); color: #fff; }
+      .cta-btn-ghost {
+        background: var(--panel);
+        color: var(--text);
+        border: 1px solid var(--border);
+        box-shadow: 0 1px 4px rgba(13,31,56,.08);
+      }
+      #s8 .stat-row {
+        display: flex; gap: 28px; margin-top: 28px; justify-content: center;
+        color: var(--muted); font-size: 14px;
+      }
+      #s8 .stat-row b { color: var(--text); font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <div id="stage">
+      <div class="glow-a"></div>
+      <div class="glow-b"></div>
+
+      <!-- ── SCENE 1: Title ── -->
+      <div class="scene active" id="s1">
+        <div class="logo">
+          <div class="mark">TT</div>
+          <div class="brand-name">TransTrack</div>
+        </div>
+        <h1>Stop losing candidates to <span class="grad-text">paperwork</span>,<br><span class="grad-text">expirations</span>, and <span class="grad-text">silent gaps</span>.</h1>
+        <p class="sub">Operational Risk Intelligence for Transplant Centers — offline-first, explainable, and built for the audits you'll actually face.</p>
+        <div class="chips">
+          <div class="chip hi">100% Offline</div>
+          <div class="chip hi">AES-256 Encrypted</div>
+          <div class="chip hi">No Cloud · No Black Box</div>
+          <div class="chip">HIPAA Architected</div>
+          <div class="chip">21 CFR Part 11</div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 2: Problem ── -->
+      <div class="scene" id="s2">
+        <div class="eyebrow"><span class="pulse"></span>The Problem</div>
+        <h2>Transplant operations don't fail <em style="font-style:normal">clinically</em>.<br>They fail <span class="grad-text">operationally.</span></h2>
+        <div class="prob-cards">
+          <div class="prob-card" id="pc1">
+            <div class="prob-icon">⏱</div>
+            <h3>Expirations slip past</h3>
+            <p>Evaluations, labs, and aHHQ documents quietly age out of currency. By the time a coordinator notices, the candidate is already inactive.</p>
+          </div>
+          <div class="prob-card" id="pc2">
+            <div class="prob-icon">🚧</div>
+            <h3>Non-clinical barriers stall</h3>
+            <p>Insurance, transport, caregiver support — the real blockers live in inboxes and spreadsheets, not in your transplant system.</p>
+          </div>
+          <div class="prob-card" id="pc3">
+            <div class="prob-icon">👁</div>
+            <h3>Status churn is invisible</h3>
+            <p>Candidates flapping between active and inactive create downstream risk no UNet view or EHR module surfaces in time to intervene.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 3: Dashboard ── -->
+      <div class="scene" id="s3">
+        <div class="dash-head">
+          <div>
+            <div class="eyebrow"><span class="pulse"></span>Live Dashboard</div>
+            <h2>Inactivation Risk Dashboard</h2>
+          </div>
+          <div style="font-size:12px;color:var(--muted);text-align:right;font-weight:500;">
+            Friday, May 22, 2026 &nbsp;·&nbsp; <span style="color:#059669;font-weight:700;">● Live</span>
+          </div>
+        </div>
+        <div class="kpi-row">
+          <div class="kpi red" id="k1">
+            <div class="k-lbl">HIGH Risk</div>
+            <div class="k-val">7</div>
+            <div class="k-sub">candidates · act now</div>
+          </div>
+          <div class="kpi warn" id="k2">
+            <div class="k-lbl">MODERATE Risk</div>
+            <div class="k-val">14</div>
+            <div class="k-sub">candidates · watch</div>
+          </div>
+          <div class="kpi warn" id="k3">
+            <div class="k-lbl">Expirations ≤ 14d</div>
+            <div class="k-val">5</div>
+            <div class="k-sub">open barriers</div>
+          </div>
+          <div class="kpi blue" id="k4">
+            <div class="k-lbl">Active Waitlist</div>
+            <div class="k-val">63</div>
+            <div class="k-sub">candidates total</div>
+          </div>
+        </div>
+        <div class="patient-list" id="pt-list">
+          <div class="pt-header">
+            <div>Candidate</div>
+            <div>Risk Score</div>
+            <div>30-day Prob</div>
+            <div>Top Factor</div>
+            <div>Status</div>
+          </div>
+          <div class="pt-row" id="pr1">
+            <div><strong style="color:var(--text);">#4821</strong> &nbsp;<span style="color:var(--muted);font-size:12px;">Liver · MELD 24</span></div>
+            <div><span class="score-num" style="color:#dc2626;">78</span></div>
+            <div>41%</div>
+            <div class="pt-factor">Open insurance barrier</div>
+            <div><span class="risk-pill risk-high">HIGH</span></div>
+          </div>
+          <div class="pt-row" id="pr2">
+            <div><strong style="color:var(--text);">#3974</strong> &nbsp;<span style="color:var(--muted);font-size:12px;">Kidney · eGFR 9</span></div>
+            <div><span class="score-num" style="color:#d97706;">61</span></div>
+            <div>29%</div>
+            <div class="pt-factor">Evaluation expiring in 6d</div>
+            <div><span class="risk-pill risk-mod">MODERATE</span></div>
+          </div>
+          <div class="pt-row" id="pr3">
+            <div><strong style="color:var(--text);">#5102</strong> &nbsp;<span style="color:var(--muted);font-size:12px;">Heart · INTERMACS 3</span></div>
+            <div><span class="score-num" style="color:#d97706;">54</span></div>
+            <div>23%</div>
+            <div class="pt-factor">Status churn × 4 / 90d</div>
+            <div><span class="risk-pill risk-mod">MODERATE</span></div>
+          </div>
+          <div class="pt-row" id="pr4">
+            <div><strong style="color:var(--text);">#2290</strong> &nbsp;<span style="color:var(--muted);font-size:12px;">Liver · MELD 18</span></div>
+            <div><span class="score-num" style="color:#059669;">22</span></div>
+            <div>8%</div>
+            <div class="pt-factor">Labs current · no barriers</div>
+            <div><span class="risk-pill risk-low">LOW</span></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 4: Risk Card detail ── -->
+      <div class="scene" id="s4">
+        <div class="risk-card">
+          <div class="risk-card-head">
+            <div>
+              <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px;font-weight:700;">Inactivation Risk · Explainable</div>
+              <div class="title">Patient #4821 &nbsp;·&nbsp; Liver Transplant &nbsp;·&nbsp; MELD 24</div>
+            </div>
+            <div class="badge-high">HIGH · 78</div>
+          </div>
+          <div class="prob-row">
+            <div class="prob-stat">
+              <div class="ps-lbl">30-day probability</div>
+              <div class="ps-val">41%</div>
+              <div class="ps-bar"><span id="pb30" style="width:0%"></span></div>
+            </div>
+            <div class="prob-stat">
+              <div class="ps-lbl">60-day probability</div>
+              <div class="ps-val">55%</div>
+              <div class="ps-bar"><span id="pb60" style="width:0%"></span></div>
+            </div>
+            <div class="prob-stat">
+              <div class="ps-lbl">90-day probability</div>
+              <div class="ps-val">68%</div>
+              <div class="ps-bar"><span id="pb90" style="width:0%"></span></div>
+            </div>
+          </div>
+          <div class="factor-section">
+            <h4>Why this score — top factors (weighted additive decomposition)</h4>
+            <div class="factor-item">
+              <div class="fi-name">Open insurance barrier</div>
+              <div class="fi-pct">+28%</div>
+              <div class="fi-bar-wrap"><div class="fi-bar-fill" id="f1" style="width:0%"></div></div>
+            </div>
+            <div class="factor-item">
+              <div class="fi-name">Evaluation expiring in 11 days</div>
+              <div class="fi-pct">+22%</div>
+              <div class="fi-bar-wrap"><div class="fi-bar-fill" id="f2" style="width:0%"></div></div>
+            </div>
+            <div class="factor-item">
+              <div class="fi-name">Labs outside currency window</div>
+              <div class="fi-pct">+14%</div>
+              <div class="fi-bar-wrap"><div class="fi-bar-fill" id="f3" style="width:0%"></div></div>
+            </div>
+            <div class="factor-item">
+              <div class="fi-name">Status churn (3 changes / 90d)</div>
+              <div class="fi-pct">+10%</div>
+              <div class="fi-bar-wrap"><div class="fi-bar-fill" id="f4" style="width:0%"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="risk-right">
+          <div class="ctf-box">
+            <div class="ctf-label">⚡ Counterfactual Intervention</div>
+            <div class="ctf-body">
+              Resolve the open insurance barrier and score drops:<br><br>
+              <strong>78 → 41</strong> &nbsp;·&nbsp; class shifts <strong>HIGH → MODERATE</strong>
+            </div>
+            <div class="score-change">
+              <div class="score-bubble sb-red">78</div>
+              <div class="score-arrow">→</div>
+              <div class="score-bubble sb-green">41</div>
+            </div>
+          </div>
+          <div class="action-list">
+            <div class="al-title">Ranked interventions — highest impact first</div>
+            <div class="action-item" id="ai1">
+              <div class="action-rank">1</div>
+              <div class="action-text">Resolve insurance barrier</div>
+              <div class="action-delta">−37 pts</div>
+            </div>
+            <div class="action-item" id="ai2">
+              <div class="action-rank">2</div>
+              <div class="action-text">Renew evaluation (due in 11d)</div>
+              <div class="action-delta">−22 pts</div>
+            </div>
+            <div class="action-item" id="ai3">
+              <div class="action-rank">3</div>
+              <div class="action-text">Refresh CBC + BMP labs</div>
+              <div class="action-delta">−14 pts</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 5: Transplant Clock ── -->
+      <div class="scene" id="s5">
+        <div class="clk-title">
+          <div class="eyebrow"><span class="pulse"></span>Real-Time Operational Pulse</div>
+          <h2>The <span class="grad-text">Transplant Clock</span></h2>
+        </div>
+        <div class="clk-layout">
+          <div>
+            <div class="clk-face">
+              <div class="clk-hz" id="clk-hz">0.0</div>
+              <div class="clk-unit">Hz</div>
+              <div class="clk-label">Pulse Rate</div>
+            </div>
+          </div>
+          <div class="clk-metrics">
+            <div class="clk-metric red" id="cm1">
+              <div class="cm-lbl">Open Barriers</div>
+              <div class="cm-val">7</div>
+            </div>
+            <div class="clk-metric warn" id="cm2">
+              <div class="cm-lbl">Next Expiration</div>
+              <div class="cm-val">6d 14h</div>
+            </div>
+            <div class="clk-metric blue" id="cm3">
+              <div class="cm-lbl">Avg Resolution Time</div>
+              <div class="cm-val">2.4d</div>
+            </div>
+            <div class="clk-metric good" id="cm4">
+              <div class="cm-lbl">Operational Freshness</div>
+              <div class="cm-val">94%</div>
+            </div>
+            <div class="clk-metric warn" id="cm5">
+              <div class="cm-lbl">Team Load</div>
+              <div class="cm-val">High</div>
+            </div>
+            <div class="clk-metric blue" id="cm6">
+              <div class="cm-lbl">Time Since Update</div>
+              <div class="cm-val">11m ago</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 6: Differentiators ── -->
+      <div class="scene" id="s6">
+        <div class="diff-intro">
+          <div class="eyebrow"><span class="pulse"></span>Why TransTrack is different</div>
+          <h2>Six things <span class="grad-text">no other platform</span> does.</h2>
+        </div>
+        <div class="diff-grid">
+          <div class="diff-card" id="dc1">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">01</div>
+            <h3>Explainable risk engine</h3>
+            <p>Deterministic, auditable scoring — weighted additive factor decomposition, same inputs → same outputs, every time. No black-box ML.</p>
+          </div>
+          <div class="diff-card" id="dc2">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">02</div>
+            <h3>Counterfactual interventions</h3>
+            <p>The highest-impact action, ranked by score drop, handed directly to the coordinator.</p>
+          </div>
+          <div class="diff-card" id="dc3">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">03</div>
+            <h3>The Transplant Clock</h3>
+            <p>Real-time operational pulse computed locally — a heartbeat for the entire program.</p>
+          </div>
+          <div class="diff-card" id="dc4">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">04</div>
+            <h3>Truly offline-first</h3>
+            <p>AES-256 SQLCipher local database. No external AI. Configurable for fully air-gapped deployment — PHI never has to leave the building.</p>
+          </div>
+          <div class="diff-card" id="dc5">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">05</div>
+            <h3>DB-layer tamper evidence</h3>
+            <p>Immutable audit log enforced by database triggers — UPDATE and DELETE are physically blocked at the DB level. SHA-256 hash chain on the optional server tier.</p>
+          </div>
+          <div class="diff-card" id="dc6">
+            <div class="diff-tag">Unique</div>
+            <div class="diff-num">06</div>
+            <h3>Sits between EHR &amp; OPTN</h3>
+            <p>FHIR R4 + HL7 v2 in. OPTN-shaped exports out. Fills the operational layer others ignore.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 7: Compliance / Security ── -->
+      <div class="scene" id="s7">
+        <div class="eyebrow"><span class="pulse"></span>Security &amp; Compliance</div>
+        <h2>Designed for the audits<br>you'll <span class="grad-text">actually face</span>.</h2>
+        <div class="compliance-row">
+          <div class="comp-badge" id="cb1">
+            <div class="cb-icon">🔒</div>
+            <div class="cb-h">HIPAA Security Rule</div>
+            <div class="cb-s">Architected to support</div>
+          </div>
+          <div class="comp-badge" id="cb2">
+            <div class="cb-icon">📋</div>
+            <div class="cb-h">21 CFR Part 11</div>
+            <div class="cb-s">Designed for alignment</div>
+          </div>
+          <div class="comp-badge" id="cb3">
+            <div class="cb-icon">🛡</div>
+            <div class="cb-h">GAMP 5 / ISO 14971</div>
+            <div class="cb-s">Risk register included</div>
+          </div>
+          <div class="comp-badge" id="cb4">
+            <div class="cb-icon">✅</div>
+            <div class="cb-h">Validation Package</div>
+            <div class="cb-s">IQ / OQ / PQ templates</div>
+          </div>
+        </div>
+        <div class="security-row">
+          <div class="sec-item" id="si1"><span class="si-dot"></span>AES-256 SQLCipher at rest</div>
+          <div class="sec-item" id="si2"><span class="si-dot"></span>bcrypt password hashing</div>
+          <div class="sec-item" id="si3"><span class="si-dot"></span>Immutable DB-trigger audit log</div>
+          <div class="sec-item" id="si4"><span class="si-dot"></span>OIDC SSO · TOTP MFA</div>
+          <div class="sec-item" id="si5"><span class="si-dot"></span>CI vulnerability audit pipeline</div>
+        </div>
+      </div>
+
+      <!-- ── SCENE 8: CTA ── -->
+      <div class="scene" id="s8">
+        <div class="cta-logo">
+          <div class="cta-mark">TT</div>
+          <div class="cta-name grad-text">TransTrack</div>
+        </div>
+        <h2>See it run on your own data —<br>entirely <span class="grad-text">offline</span>.</h2>
+        <p class="cta-sub">Download for Windows, macOS, or Linux. Or build from source in three commands. No accounts. No cloud. No external AI.</p>
+        <div class="cta-buttons">
+          <a class="cta-btn cta-btn-primary" href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases">Download Installers →</a>
+          <a class="cta-btn cta-btn-ghost" href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack">View on GitHub</a>
+          <a class="cta-btn cta-btn-ghost" href="mailto:Trans_Track@outlook.com">Talk to us</a>
+        </div>
+        <div class="stat-row">
+          <span><b>100%</b> offline by default</span>
+          <span><b>CI</b> vuln audit pipeline</span>
+          <span><b>AES-256</b> at rest</span>
+          <span><b>No</b> cloud · no AI black box</span>
+        </div>
+      </div>
+
+      <!-- progress & controls -->
+      <div id="progress-bar"><div id="progress-fill"></div></div>
+      <div id="dots"></div>
+      <div id="controls">
+        <button class="ctrl-btn" id="btn-prev" title="Previous">‹</button>
+        <button class="ctrl-btn" id="btn-play" title="Pause">⏸</button>
+        <button class="ctrl-btn" id="btn-next" title="Next">›</button>
+      </div>
+    </div>
+
+    <script>
+      const SCENE_DURATIONS = [5500, 7000, 7000, 8000, 7000, 7500, 6500, 8000]; // ms per scene
+      const scenes = document.querySelectorAll('.scene');
+      const nScenes = scenes.length;
+      let current = 0;
+      let playing = true;
+      let elapsed = 0;
+      let lastTs = null;
+      let rafId = null;
+
+      // Build dots
+      const dotsEl = document.getElementById('dots');
+      for (let i = 0; i < nScenes; i++) {
+        const d = document.createElement('div');
+        d.className = 'dot' + (i === 0 ? ' active' : '');
+        d.addEventListener('click', () => goTo(i));
+        dotsEl.appendChild(d);
+      }
+
+      function getDots() { return dotsEl.querySelectorAll('.dot'); }
+
+      function triggerSceneAnimations(idx) {
+        if (idx === 1) { // scene 2: problem cards
+          setTimeout(() => document.getElementById('pc1').classList.add('in'), 200);
+          setTimeout(() => document.getElementById('pc2').classList.add('in'), 500);
+          setTimeout(() => document.getElementById('pc3').classList.add('in'), 800);
+        }
+        if (idx === 2) { // scene 3: dashboard
+          ['k1','k2','k3','k4'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 150 + i * 120));
+          setTimeout(() => document.getElementById('pt-list').classList.add('in'), 700);
+          ['pr1','pr2','pr3','pr4'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 900 + i * 180));
+        }
+        if (idx === 3) { // scene 4: risk card
+          setTimeout(() => {
+            document.getElementById('pb30').style.width = '41%';
+            document.getElementById('pb60').style.width = '55%';
+            document.getElementById('pb90').style.width = '68%';
+            document.getElementById('f1').style.width = '88%';
+            document.getElementById('f2').style.width = '70%';
+            document.getElementById('f3').style.width = '50%';
+            document.getElementById('f4').style.width = '38%';
+          }, 400);
+          ['ai1','ai2','ai3'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 900 + i * 220));
+        }
+        if (idx === 4) { // scene 5: clock
+          let hz = 0;
+          const target = 2.4;
+          const el = document.getElementById('clk-hz');
+          const step = () => {
+            hz = Math.min(hz + 0.12, target);
+            el.textContent = hz.toFixed(1);
+            if (hz < target) requestAnimationFrame(step);
+          };
+          setTimeout(step, 300);
+          ['cm1','cm2','cm3','cm4','cm5','cm6'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 400 + i * 140));
+        }
+        if (idx === 5) { // scene 6: diffs
+          ['dc1','dc2','dc3','dc4','dc5','dc6'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 200 + i * 140));
+        }
+        if (idx === 6) { // scene 7: compliance
+          ['cb1','cb2','cb3','cb4'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 200 + i * 130));
+          ['si1','si2','si3','si4','si5'].forEach((id, i) =>
+            setTimeout(() => document.getElementById(id).classList.add('in'), 900 + i * 120));
+        }
+      }
+
+      // Reset per-scene animation classes
+      function resetSceneAnimations(idx) {
+        const animatedIds = {
+          1: ['pc1','pc2','pc3'],
+          2: ['k1','k2','k3','k4','pt-list','pr1','pr2','pr3','pr4'],
+          3: ['ai1','ai2','ai3'],
+          4: ['cm1','cm2','cm3','cm4','cm5','cm6'],
+          5: ['dc1','dc2','dc3','dc4','dc5','dc6'],
+          6: ['cb1','cb2','cb3','cb4','si1','si2','si3','si4','si5'],
+        };
+        if (animatedIds[idx]) {
+          animatedIds[idx].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.classList.remove('in');
+          });
+        }
+        if (idx === 3) {
+          ['pb30','pb60','pb90','f1','f2','f3','f4'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.style.width = '0%';
+          });
+        }
+        if (idx === 4) {
+          const el = document.getElementById('clk-hz');
+          if (el) el.textContent = '0.0';
+        }
+      }
+
+      function goTo(idx) {
+        scenes[current].classList.remove('active');
+        getDots()[current].classList.remove('active');
+        resetSceneAnimations(idx);
+        current = ((idx % nScenes) + nScenes) % nScenes;
+        elapsed = 0;
+        scenes[current].classList.add('active');
+        getDots()[current].classList.add('active');
+        triggerSceneAnimations(current);
+      }
+
+      function tick(ts) {
+        if (!lastTs) lastTs = ts;
+        const dt = ts - lastTs;
+        lastTs = ts;
+        if (playing) {
+          elapsed += dt;
+          const dur = SCENE_DURATIONS[current];
+          const pct = Math.min((elapsed / dur) * 100, 100);
+          document.getElementById('progress-fill').style.width = pct + '%';
+          if (elapsed >= dur) {
+            goTo(current + 1);
+          }
+        }
+        rafId = requestAnimationFrame(tick);
+      }
+
+      document.getElementById('btn-play').addEventListener('click', () => {
+        playing = !playing;
+        document.getElementById('btn-play').textContent = playing ? '⏸' : '▶';
+        if (playing) lastTs = null;
+      });
+      document.getElementById('btn-next').addEventListener('click', () => goTo(current + 1));
+      document.getElementById('btn-prev').addEventListener('click', () => goTo(current - 1));
+
+      // Keyboard nav
+      document.addEventListener('keydown', e => {
+        if (e.key === 'ArrowRight' || e.key === ' ') goTo(current + 1);
+        if (e.key === 'ArrowLeft') goTo(current - 1);
+        if (e.key === 'p' || e.key === 'P') document.getElementById('btn-play').click();
+      });
+
+      // Boot
+      triggerSceneAnimations(0);
+      rafId = requestAnimationFrame(tick);
+    </script>
+  </body>
+</html>

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -1,0 +1,1231 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TransTrack — Operational Risk Intelligence for Transplant Centers</title>
+    <meta
+      name="description"
+      content="TransTrack is the offline-first transplant operations platform that stops candidates from being inactivated for non-clinical reasons. HIPAA-architected. Explainable. No cloud required."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #07101e;
+        --bg-2: #0c1a2e;
+        --panel: #0f213b;
+        --panel-2: #122a49;
+        --border: rgba(120, 170, 220, 0.14);
+        --text: #e7eef9;
+        --muted: #9bb0cc;
+        --accent: #38bdf8;
+        --accent-2: #22d3ee;
+        --warn: #f59e0b;
+        --good: #10b981;
+        --bad: #ef4444;
+        --grad: linear-gradient(135deg, #38bdf8 0%, #22d3ee 50%, #34d399 100%);
+        --grad-soft: linear-gradient(
+          180deg,
+          rgba(56, 189, 248, 0.15),
+          rgba(34, 211, 238, 0)
+        );
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family:
+          "Inter",
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          sans-serif;
+        -webkit-font-smoothing: antialiased;
+        line-height: 1.55;
+      }
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        color: #7dd3fc;
+      }
+      code,
+      .mono {
+        font-family: "JetBrains Mono", ui-monospace, Consolas, monospace;
+      }
+
+      .container {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+
+      /* NAV */
+      header.nav {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        backdrop-filter: blur(10px);
+        background: rgba(7, 16, 30, 0.7);
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 14px 0;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 800;
+        letter-spacing: 0.2px;
+      }
+      .brand-mark {
+        width: 30px;
+        height: 30px;
+        border-radius: 8px;
+        background: var(--grad);
+        display: grid;
+        place-items: center;
+        color: #002233;
+        font-weight: 800;
+        font-size: 14px;
+      }
+      .brand-name {
+        font-size: 17px;
+      }
+      .nav-links {
+        display: flex;
+        gap: 22px;
+        align-items: center;
+      }
+      .nav-links a {
+        color: var(--muted);
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .nav-links a:hover {
+        color: var(--text);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 11px 18px;
+        border-radius: 10px;
+        font-weight: 600;
+        font-size: 14px;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition:
+          transform 0.15s ease,
+          background 0.2s ease,
+          border-color 0.2s ease;
+      }
+      .btn-primary {
+        background: var(--grad);
+        color: #002233;
+      }
+      .btn-primary:hover {
+        transform: translateY(-1px);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--text);
+        border-color: var(--border);
+      }
+      .btn-ghost:hover {
+        border-color: rgba(120, 170, 220, 0.4);
+      }
+
+      /* HERO */
+      .hero {
+        position: relative;
+        overflow: hidden;
+        padding: 72px 0 64px;
+      }
+      .hero::before {
+        content: "";
+        position: absolute;
+        inset: -200px -100px auto auto;
+        width: 720px;
+        height: 720px;
+        background: radial-gradient(
+          closest-side,
+          rgba(56, 189, 248, 0.18),
+          transparent 70%
+        );
+        filter: blur(20px);
+        pointer-events: none;
+      }
+      .hero::after {
+        content: "";
+        position: absolute;
+        inset: auto auto -260px -160px;
+        width: 700px;
+        height: 700px;
+        background: radial-gradient(
+          closest-side,
+          rgba(52, 211, 153, 0.14),
+          transparent 70%
+        );
+        filter: blur(20px);
+        pointer-events: none;
+      }
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 48px;
+        align-items: center;
+      }
+      @media (max-width: 900px) {
+        .hero-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.08);
+        color: #7dd3fc;
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.4px;
+        text-transform: uppercase;
+      }
+      .eyebrow .dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #34d399;
+        box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.18);
+      }
+      h1.hero-title {
+        font-size: clamp(34px, 4.6vw, 56px);
+        line-height: 1.05;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        margin: 18px 0 16px;
+      }
+      h1.hero-title .grad {
+        background: var(--grad);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+      .hero-sub {
+        color: var(--muted);
+        font-size: 18px;
+        max-width: 600px;
+      }
+      .hero-cta {
+        display: flex;
+        gap: 12px;
+        margin-top: 28px;
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: flex;
+        gap: 22px;
+        margin-top: 28px;
+        color: var(--muted);
+        font-size: 13px;
+        flex-wrap: wrap;
+      }
+      .hero-meta b {
+        color: var(--text);
+        font-weight: 600;
+      }
+
+      /* HERO CARD MOCK */
+      .mock {
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.03),
+          rgba(255, 255, 255, 0.01)
+        );
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 18px;
+        box-shadow: 0 30px 80px -30px rgba(0, 0, 0, 0.7);
+      }
+      .mock-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 14px;
+      }
+      .mock-head .pill {
+        padding: 4px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        border-radius: 999px;
+        background: rgba(239, 68, 68, 0.12);
+        color: #fca5a5;
+        border: 1px solid rgba(239, 68, 68, 0.25);
+      }
+      .mock-head .title {
+        font-weight: 700;
+        font-size: 14px;
+      }
+      .mock-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+      .stat {
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 14px;
+      }
+      .stat .lbl {
+        font-size: 11px;
+        text-transform: uppercase;
+        color: var(--muted);
+        letter-spacing: 0.5px;
+      }
+      .stat .val {
+        font-size: 24px;
+        font-weight: 800;
+        margin-top: 4px;
+      }
+      .bar {
+        position: relative;
+        height: 8px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.06);
+        overflow: hidden;
+        margin-top: 10px;
+      }
+      .bar > span {
+        display: block;
+        height: 100%;
+        background: var(--grad);
+        border-radius: 999px;
+      }
+      .factors {
+        margin-top: 10px;
+        display: grid;
+        gap: 8px;
+      }
+      .factor {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 10px;
+        align-items: center;
+        font-size: 13px;
+      }
+      .factor .name {
+        color: var(--muted);
+      }
+      .factor .pct {
+        font-variant-numeric: tabular-nums;
+        color: var(--text);
+        font-weight: 600;
+      }
+      .factor-bar {
+        grid-column: 1 / -1;
+        height: 6px;
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 999px;
+        overflow: hidden;
+      }
+      .factor-bar > span {
+        display: block;
+        height: 100%;
+        background: linear-gradient(90deg, #f59e0b, #ef4444);
+        border-radius: 999px;
+      }
+      .ctf {
+        margin-top: 14px;
+        padding: 12px 14px;
+        background: rgba(52, 211, 153, 0.07);
+        border: 1px solid rgba(52, 211, 153, 0.25);
+        border-radius: 12px;
+        font-size: 13px;
+      }
+      .ctf b {
+        color: #6ee7b7;
+      }
+
+      /* SECTIONS */
+      section {
+        padding: 72px 0;
+        border-top: 1px solid var(--border);
+      }
+      .section-head {
+        max-width: 760px;
+        margin: 0 auto 40px;
+        text-align: center;
+      }
+      .section-head .eyebrow {
+        margin-bottom: 14px;
+      }
+      h2 {
+        font-size: clamp(26px, 3vw, 38px);
+        line-height: 1.1;
+        font-weight: 800;
+        letter-spacing: -0.01em;
+        margin: 0 0 12px;
+      }
+      h2 .grad {
+        background: var(--grad);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+      .lead {
+        color: var(--muted);
+        font-size: 17px;
+      }
+
+      /* PROBLEM */
+      .problem-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      @media (max-width: 800px) {
+        .problem-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .prob {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 22px;
+      }
+      .prob h3 {
+        margin: 12px 0 6px;
+        font-size: 17px;
+      }
+      .prob p {
+        color: var(--muted);
+        margin: 0;
+        font-size: 14px;
+      }
+      .icon {
+        width: 38px;
+        height: 38px;
+        border-radius: 10px;
+        background: rgba(56, 189, 248, 0.12);
+        color: #7dd3fc;
+        display: grid;
+        place-items: center;
+        font-size: 18px;
+        font-weight: 800;
+      }
+
+      /* DIFFERENT */
+      .diff-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 18px;
+      }
+      @media (max-width: 800px) {
+        .diff-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .diff {
+        position: relative;
+        background:
+          var(--grad-soft),
+          linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0.03),
+            rgba(255, 255, 255, 0.01)
+          );
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 26px;
+        overflow: hidden;
+      }
+      .diff::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+          radial-gradient(
+            600px 200px at 0% 0%,
+            rgba(56, 189, 248, 0.1),
+            transparent 60%
+          ),
+          radial-gradient(
+            400px 200px at 100% 100%,
+            rgba(52, 211, 153, 0.08),
+            transparent 60%
+          );
+        pointer-events: none;
+      }
+      .diff h3 {
+        margin: 12px 0 8px;
+        font-size: 19px;
+        position: relative;
+      }
+      .diff p {
+        color: var(--muted);
+        margin: 0;
+        position: relative;
+      }
+      .diff .icon {
+        background: rgba(52, 211, 153, 0.12);
+        color: #6ee7b7;
+        position: relative;
+      }
+      .diff .tag {
+        position: absolute;
+        top: 18px;
+        right: 18px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+        color: #6ee7b7;
+        font-weight: 700;
+      }
+
+      /* COMPARE */
+      .compare {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        overflow: hidden;
+      }
+      .compare table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .compare th,
+      .compare td {
+        padding: 14px 16px;
+        text-align: left;
+        font-size: 14px;
+        border-bottom: 1px solid var(--border);
+        vertical-align: top;
+      }
+      .compare thead th {
+        background: rgba(255, 255, 255, 0.02);
+        color: var(--muted);
+        font-weight: 600;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.6px;
+      }
+      .compare tbody tr:last-child td {
+        border-bottom: none;
+      }
+      .compare td.col-tt {
+        background: rgba(56, 189, 248, 0.05);
+        color: var(--text);
+      }
+      .ck {
+        color: #6ee7b7;
+        font-weight: 700;
+      }
+      .x {
+        color: #fca5a5;
+      }
+      .compare .row-h {
+        font-weight: 600;
+      }
+      @media (max-width: 800px) {
+        .compare {
+          overflow-x: auto;
+        }
+        .compare table {
+          min-width: 720px;
+        }
+      }
+
+      /* FEATURES */
+      .feat-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+      @media (max-width: 1000px) {
+        .feat-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      @media (max-width: 640px) {
+        .feat-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      .feat {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 22px;
+      }
+      .feat h3 {
+        font-size: 16px;
+        margin: 12px 0 6px;
+      }
+      .feat p {
+        color: var(--muted);
+        margin: 0;
+        font-size: 14px;
+      }
+
+      /* TRUST STRIP */
+      .trust {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 14px;
+        margin-top: 26px;
+      }
+      @media (max-width: 800px) {
+        .trust {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .badge {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 16px;
+        text-align: center;
+      }
+      .badge .b-h {
+        font-weight: 700;
+        font-size: 14px;
+      }
+      .badge .b-s {
+        color: var(--muted);
+        font-size: 12px;
+        margin-top: 4px;
+      }
+
+      /* CTA */
+      .cta-band {
+        background:
+          var(--grad-soft),
+          linear-gradient(
+            180deg,
+            rgba(255, 255, 255, 0.04),
+            rgba(255, 255, 255, 0.01)
+          );
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        padding: 36px;
+        text-align: center;
+      }
+      .cta-band h3 {
+        font-size: clamp(22px, 2.4vw, 30px);
+        margin: 0 0 8px;
+      }
+      .cta-band p {
+        color: var(--muted);
+        margin: 0 0 20px;
+      }
+
+      /* FOOTER */
+      footer {
+        padding: 36px 0 60px;
+        color: var(--muted);
+        font-size: 13px;
+        border-top: 1px solid var(--border);
+      }
+      .foot-grid {
+        display: flex;
+        justify-content: space-between;
+        gap: 18px;
+        flex-wrap: wrap;
+      }
+      .disclaimer {
+        max-width: 720px;
+        line-height: 1.6;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="nav">
+      <div class="container nav-inner">
+        <div class="brand">
+          <div class="brand-mark">TT</div>
+          <div class="brand-name">TransTrack</div>
+        </div>
+        <nav class="nav-links">
+          <a href="#different">Why different</a>
+          <a href="#features">Features</a>
+          <a href="#compare">Compare</a>
+          <a href="#compliance">Compliance</a>
+          <a
+            class="btn btn-ghost"
+            href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack"
+            >GitHub</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <!-- HERO -->
+    <section class="hero" style="border-top: none">
+      <div class="container hero-grid">
+        <div>
+          <span class="eyebrow"
+            ><span class="dot"></span> Operational Risk Intelligence for
+            Transplant</span
+          >
+          <h1 class="hero-title">
+            Stop losing candidates to <span class="grad">paperwork</span>,
+            <span class="grad">expirations</span>, and
+            <span class="grad">silent gaps</span>.
+          </h1>
+          <p class="hero-sub">
+            TransTrack is the offline-first transplant operations platform that
+            sits between your EHR and OPTN/UNet. It surfaces the
+            <b style="color: #fff">non-clinical</b> reasons candidates get
+            inactivated — and tells your coordinators exactly which intervention
+            will move the score the most.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="#different"
+              >See what makes it different →</a
+            >
+            <a
+              class="btn btn-ghost"
+              href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases"
+              >Download</a
+            >
+          </div>
+          <div class="hero-meta">
+            <span><b>0</b> known vulnerabilities</span>
+            <span><b>100%</b> offline by default</span>
+            <span><b>AES-256</b> at rest (SQLCipher)</span>
+            <span><b>No</b> cloud, no AI black box</span>
+          </div>
+        </div>
+
+        <!-- Mock Risk Card -->
+        <div class="mock" aria-hidden="true">
+          <div class="mock-head">
+            <div class="title">Inactivation Risk · Patient #4821</div>
+            <div class="pill">HIGH · 78</div>
+          </div>
+          <div class="mock-row">
+            <div class="stat">
+              <div class="lbl">30-day probability</div>
+              <div class="val">41%</div>
+              <div class="bar"><span style="width: 41%"></span></div>
+            </div>
+            <div class="stat">
+              <div class="lbl">90-day probability</div>
+              <div class="val">68%</div>
+              <div class="bar"><span style="width: 68%"></span></div>
+            </div>
+          </div>
+
+          <div style="margin-top: 4px; font-size: 12px; color: var(--muted)">
+            Why this score (top factors)
+          </div>
+          <div class="factors">
+            <div class="factor">
+              <div class="name">Open insurance barrier</div>
+              <div class="pct">28%</div>
+              <div class="factor-bar"><span style="width: 88%"></span></div>
+            </div>
+            <div class="factor">
+              <div class="name">Evaluation expiring in 11 days</div>
+              <div class="pct">22%</div>
+              <div class="factor-bar"><span style="width: 70%"></span></div>
+            </div>
+            <div class="factor">
+              <div class="name">Labs outside currency window</div>
+              <div class="pct">14%</div>
+              <div class="factor-bar"><span style="width: 50%"></span></div>
+            </div>
+            <div class="factor">
+              <div class="name">Status churn (3 changes / 30d)</div>
+              <div class="pct">10%</div>
+              <div class="factor-bar"><span style="width: 38%"></span></div>
+            </div>
+          </div>
+
+          <div class="ctf">
+            <b>Counterfactual:</b> Resolve insurance barrier →
+            score drops <b>78 → 41</b> ·
+            class shifts <b>HIGH → MODERATE</b>.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- PROBLEM -->
+    <section id="problem">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">The problem</span>
+          <h2>Transplant operations don't fail clinically. They fail <span class="grad">operationally.</span></h2>
+          <p class="lead">
+            Most candidates aren't lost because of medicine. They're lost
+            because an evaluation expired, an insurance form sat in a queue,
+            labs aged out, or a status change slipped through three handoffs.
+            Existing tools — UNet, EHR transplant modules, legacy systems,
+            spreadsheets — weren't built to catch any of that.
+          </p>
+        </div>
+        <div class="problem-grid">
+          <div class="prob">
+            <div class="icon">EX</div>
+            <h3>Expirations slip past</h3>
+            <p>
+              Evaluations, labs, and aHHQ documents quietly age out of currency.
+              By the time a coordinator notices, the candidate has already been
+              moved to inactive.
+            </p>
+          </div>
+          <div class="prob">
+            <div class="icon">BA</div>
+            <h3>Non-clinical barriers stall</h3>
+            <p>
+              Insurance, transport, caregiver support, financial review — these
+              are the real blockers. They live in inboxes and spreadsheets, not
+              in your transplant system.
+            </p>
+          </div>
+          <div class="prob">
+            <div class="icon">CH</div>
+            <h3>Status churn is invisible</h3>
+            <p>
+              Candidates flapping between active and inactive create downstream
+              risk that no UNet view, EHR module, or dashboard surfaces in time
+              to intervene.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- DIFFERENT -->
+    <section id="different">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Why TransTrack is different</span>
+          <h2>
+            Six things <span class="grad">no other platform</span> in this
+            space does.
+          </h2>
+          <p class="lead">
+            UNet does allocation. EHRs do encounters. Legacy transplant
+            systems do data entry. TransTrack does the one thing none of them
+            do well: tell you, in real time, which candidates are about to
+            slip — and why — and what to do about it.
+          </p>
+        </div>
+
+        <div class="diff-grid">
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">01</div>
+            <h3>An Inactivation Risk Engine that explains itself</h3>
+            <p>
+              Deterministic, auditable scoring with full per-factor
+              decomposition (SHAP-style additive) and 30 / 60 / 90-day
+              calibrated probabilities. No black-box ML. No cloud inference.
+              Same inputs → same output, every time.
+            </p>
+          </div>
+
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">02</div>
+            <h3>Counterfactual interventions, ranked by impact</h3>
+            <p>
+              "If you resolve this insurance barrier, the score drops from
+              <b>78</b> to <b>41</b>." TransTrack hands the coordinator the
+              highest-impact action first — with the projected score change
+              already calculated.
+            </p>
+          </div>
+
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">03</div>
+            <h3>The Transplant Clock — a real-time operational pulse</h3>
+            <p>
+              Time-since-last-update, open barriers, lab gaps, next expiration,
+              team load, and a live pulse rate that rises as risk accumulates.
+              All computed locally. A heartbeat for the entire program.
+            </p>
+          </div>
+
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">04</div>
+            <h3>Truly offline-first — your PHI never leaves the building</h3>
+            <p>
+              AES-256 SQLCipher database, deterministic encryption, no
+              telemetry, no cloud calls, no external AI. Air-gappable by
+              design. The optional server tier is yours, on your infrastructure,
+              when you want it.
+            </p>
+          </div>
+
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">05</div>
+            <h3>Tamper-evident audit at the database layer</h3>
+            <p>
+              Append-only audit log with a SHA-256 hash chain enforced by
+              database triggers — UPDATE and DELETE are physically blocked.
+              A verification endpoint proves chain integrity to your auditors.
+            </p>
+          </div>
+
+          <div class="diff">
+            <span class="tag">Unique</span>
+            <div class="icon">06</div>
+            <h3>Sits between EHR and OPTN — instead of replacing them</h3>
+            <p>
+              FHIR R4 + HL7 v2 in. OPTN-shaped exports out. TransTrack doesn't
+              try to be your EHR or your registry. It fills the operational
+              layer the others ignore — coordination, readiness, and
+              inactivation prevention.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- COMPARE -->
+    <section id="compare">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Side by side</span>
+          <h2>How TransTrack compares</h2>
+          <p class="lead">
+            Most teams cobble together UNet, an EHR module, a couple of
+            spreadsheets, and a vendor system from the 2000s. Here's what each
+            actually delivers.
+          </p>
+        </div>
+
+        <div class="compare">
+          <table>
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th>TransTrack</th>
+                <th>UNOS UNet</th>
+                <th>EHR transplant module</th>
+                <th>Legacy systems · Spreadsheets</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="row-h">Operational risk intelligence (non-clinical inactivation)</td>
+                <td class="col-tt"><span class="ck">✓</span> Core focus, with explainable scoring</td>
+                <td class="x">— Allocation only</td>
+                <td class="x">— Encounter-centric</td>
+                <td class="x">— Manual tracking</td>
+              </tr>
+              <tr>
+                <td class="row-h">Counterfactual "what if" interventions</td>
+                <td class="col-tt"><span class="ck">✓</span> Ranked by score impact</td>
+                <td class="x">—</td>
+                <td class="x">—</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">Offline-first, no cloud required</td>
+                <td class="col-tt"><span class="ck">✓</span> AES-256 local SQLCipher</td>
+                <td class="x">Cloud-only</td>
+                <td class="x">Cloud / hospital network</td>
+                <td>Mixed</td>
+              </tr>
+              <tr>
+                <td class="row-h">Tamper-evident audit (DB-level immutability)</td>
+                <td class="col-tt"><span class="ck">✓</span> SHA-256 hash chain + triggers</td>
+                <td>App-level only</td>
+                <td>App-level only</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">FHIR R4 + HL7 v2 ingestion</td>
+                <td class="col-tt"><span class="ck">✓</span> MLLP/TLS, ADT/ORU, ACK</td>
+                <td class="x">—</td>
+                <td><span class="ck">✓</span> Vendor-specific</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">Full clinical calculator suite (MELD/MELD-Na/3.0/PELD/LAS/KDPI/EPTS)</td>
+                <td class="col-tt"><span class="ck">✓</span> Reference-grade, audited</td>
+                <td><span class="ck">✓</span></td>
+                <td>Partial</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">Real-time operational pulse / Transplant Clock</td>
+                <td class="col-tt"><span class="ck">✓</span> Computed locally</td>
+                <td class="x">—</td>
+                <td class="x">—</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">21 CFR Part 11 architecture</td>
+                <td class="col-tt"><span class="ck">✓</span> Validation package included</td>
+                <td>N/A</td>
+                <td>Partial</td>
+                <td class="x">—</td>
+              </tr>
+              <tr>
+                <td class="row-h">Deployable on-prem or fully air-gapped</td>
+                <td class="col-tt"><span class="ck">✓</span></td>
+                <td class="x">—</td>
+                <td class="x">—</td>
+                <td>—</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p
+          style="
+            color: var(--muted);
+            font-size: 12px;
+            margin-top: 14px;
+            text-align: center;
+          "
+        >
+          UNOS UNet, OPTN, Epic, Cerner, OTTR, Phoenix and other names are
+          trademarks of their respective owners and are referenced for
+          comparison only.
+        </p>
+      </div>
+    </section>
+
+    <!-- FEATURES -->
+    <section id="features">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">What's inside</span>
+          <h2>An entire transplant operations stack — in one signed binary.</h2>
+          <p class="lead">
+            Built as a single Electron desktop app or a Postgres-backed thin
+            client. Same UI. Same code. Your choice of deployment.
+          </p>
+        </div>
+
+        <div class="feat-grid">
+          <div class="feat">
+            <div class="icon">RI</div>
+            <h3>Inactivation Risk Engine v2</h3>
+            <p>
+              8-factor weighted model, calibrated 30/60/90-day probabilities,
+              center-level dollar-impact projection, recalibratable per site
+              during PQ.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">TC</div>
+            <h3>Transplant Clock</h3>
+            <p>
+              Pulse rate (Hz), operational freshness, team load indicator,
+              average resolution time, next expiration countdown.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">WL</div>
+            <h3>Waitlist & candidate management</h3>
+            <p>
+              Demographics, evaluations, configurable readiness indicators,
+              status workflows, search and filter at scale.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">BA</div>
+            <h3>Readiness barriers</h3>
+            <p>
+              Track non-clinical obstacles — insurance, logistics, caregiver
+              support — assigned to social work, financial, or coordinator
+              roles.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">OO</div>
+            <h3>Organ offer state machine</h3>
+            <p>
+              PENDING → ACCEPTED_PROVISIONAL → ACCEPTED_FINAL / DECLINED /
+              EXPIRED / RESCINDED, with structured decline-reason codes.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">PT</div>
+            <h3>Post-transplant follow-up</h3>
+            <p>
+              Transplant events, immunosuppression regimens, rejection
+              episodes, biopsies, post-tx readmissions.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">LD</div>
+            <h3>Living donor workflow</h3>
+            <p>
+              Separate donor record, evaluation steps, status state machine,
+              auto-generated 6/12/24-month OPTN Policy 14-style follow-ups.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">FH</div>
+            <h3>FHIR R4 + HL7 v2</h3>
+            <p>
+              Inbound MLLP/TLS with ACK generation, ADT^A01/A03/A04/A08 +
+              ORU^R01, FHIR R4 Patient/Observation/Encounter/MedicationRequest/
+              AllergyIntolerance.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">CA</div>
+            <h3>Calculators</h3>
+            <p>
+              MELD · MELD-Na · MELD 3.0 · PELD · LAS · KDPI/KDRI · EPTS — with
+              percentile mapping. Reference-only; allocation stays in UNet.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">AU</div>
+            <h3>Hash-chained audit</h3>
+            <p>
+              Append-only with DB-trigger UPDATE/DELETE blocks. SHA-256 prev/
+              entry hashes. Verification endpoint for auditors. Optional SIEM
+              forwarding.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">SO</div>
+            <h3>Hospital SSO + MFA</h3>
+            <p>
+              SAML 2.0, OIDC, TOTP MFA with recovery codes, account lockout,
+              password policy + history. Argon2id at rest.
+            </p>
+          </div>
+          <div class="feat">
+            <div class="icon">DR</div>
+            <h3>Backup & disaster recovery</h3>
+            <p>
+              Encrypted local backups, restore tooling, validation IQ/OQ/PQ
+              templates, runbooks, and incident response policies in the box.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- COMPLIANCE -->
+    <section id="compliance">
+      <div class="container">
+        <div class="section-head">
+          <span class="eyebrow">Compliance posture</span>
+          <h2>Designed for the audits you'll face — not the ones you won't.</h2>
+          <p class="lead">
+            TransTrack is architected to support HIPAA Security Rule controls
+            and aligned with 21 CFR Part 11 electronic-records requirements.
+            "Aligned" describes the design controls — formal certification is
+            performed by the deploying organization.
+          </p>
+        </div>
+
+        <div class="trust">
+          <div class="badge">
+            <div class="b-h">HIPAA Security Rule</div>
+            <div class="b-s">Architected to support</div>
+          </div>
+          <div class="badge">
+            <div class="b-h">21 CFR Part 11</div>
+            <div class="b-s">Designed for alignment</div>
+          </div>
+          <div class="badge">
+            <div class="b-h">GAMP 5 / ISO 14971</div>
+            <div class="b-s">Risk register included</div>
+          </div>
+          <div class="badge">
+            <div class="b-h">Validation package</div>
+            <div class="b-s">IQ / OQ / PQ templates</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section>
+      <div class="container">
+        <div class="cta-band">
+          <h3>See it run on your own data — entirely offline.</h3>
+          <p>
+            Download the Windows, macOS, or Linux build. Or build from source
+            in three commands. No accounts, no cloud, no telemetry.
+          </p>
+          <div
+            style="
+              display: flex;
+              gap: 12px;
+              justify-content: center;
+              flex-wrap: wrap;
+            "
+          >
+            <a
+              class="btn btn-primary"
+              href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack/releases"
+              >Download installers</a
+            >
+            <a
+              class="btn btn-ghost"
+              href="https://github.com/NeuroKoder3/TransTrackMedical-TransTrack"
+              >View on GitHub</a
+            >
+            <a class="btn btn-ghost" href="mailto:Trans_Track@outlook.com"
+              >Talk to us</a
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <div class="container foot-grid">
+        <div>
+          <div class="brand" style="margin-bottom: 10px">
+            <div class="brand-mark">TT</div>
+            <div class="brand-name">TransTrack</div>
+          </div>
+          <div>© TransTrack Medical Software. All rights reserved.</div>
+        </div>
+        <div class="disclaimer">
+          TransTrack is operational decision-support software, not a clinical
+          decision-making system. It does not perform organ allocation and
+          does not replace UNOS/OPTN systems. "HIPAA aligned" and "Part 11
+          architected" describe design controls, not certifications. Any
+          formal certification (SOC 2 / HITRUST / 21 CFR Part 11 validation /
+          FDA determinations) is the responsibility of the deploying
+          organization and its qualified auditors.
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/scripts/epic-production-check.mjs
+++ b/scripts/epic-production-check.mjs
@@ -1,0 +1,177 @@
+/**
+ * Epic PRODUCTION connectivity verification.
+ *
+ * Runs the same token → scope → metadata → patient-pull sequence as the
+ * sandbox diagnostic, but against a customer's production (or TST)
+ * Interconnect endpoints, and writes a timestamped evidence file to
+ * demo-evidence/ suitable for due-diligence packets.
+ *
+ * All configuration comes from environment variables so no production
+ * endpoint, client ID, or key path is ever committed to the repository:
+ *
+ *   EPIC_PROD_CLIENT_ID         (required) production client ID from Epic
+ *                               Connection Hub / customer's App Market record
+ *   EPIC_PROD_PRIVATE_KEY_FILE  (required) path to the RS384 private key PEM
+ *   EPIC_PROD_TOKEN_URL         (required) customer Interconnect token URL,
+ *                               e.g. https://ic.example-health.org/interconnect-prd-fhir/oauth2/token
+ *   EPIC_PROD_FHIR_BASE         (required) customer FHIR R4 base,
+ *                               e.g. https://ic.example-health.org/interconnect-prd-fhir/api/FHIR/R4
+ *   EPIC_PROD_TEST_PATIENT      (optional) FHIR Patient id to pull; when unset,
+ *                               the run stops after the metadata check (no PHI touched)
+ *   EPIC_PROD_KID               (optional) JWKS key id, default transtrack-epic-1
+ *
+ * Usage: node scripts/epic-production-check.mjs
+ *
+ * NOTE ON PHI: when EPIC_PROD_TEST_PATIENT is set, the evidence file records
+ * resource COUNTS only — no names, DOBs, MRNs, or values are written to disk.
+ */
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const { createEpicClientFromKeyFile, DEFAULT_SCOPES } = require('../server/src/integrations/epic/client.js');
+
+const CLIENT_ID   = process.env.EPIC_PROD_CLIENT_ID;
+const KEY_FILE    = process.env.EPIC_PROD_PRIVATE_KEY_FILE;
+const TOKEN_URL   = process.env.EPIC_PROD_TOKEN_URL;
+const FHIR_BASE   = process.env.EPIC_PROD_FHIR_BASE;
+const TEST_PATIENT = process.env.EPIC_PROD_TEST_PATIENT || null;
+const KID         = process.env.EPIC_PROD_KID || 'transtrack-epic-1';
+
+function tick(label) { process.stdout.write(`\n  \x1b[32m✓\x1b[0m ${label}`); }
+function fail(label) { process.stdout.write(`\n  \x1b[31m✗\x1b[0m ${label}`); }
+function info(label) { process.stdout.write(`\n  \x1b[36m·\x1b[0m ${label}`); }
+function section(title) { console.log(`\n\x1b[1m\x1b[34m── ${title} ──\x1b[0m`); }
+
+const evidence = [];
+function record(line) { evidence.push(line); }
+
+function redactHost(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return '(invalid URL)';
+  }
+}
+
+async function run() {
+  console.log('\n\x1b[1mTransTrack × Epic PRODUCTION Verification\x1b[0m');
+
+  const missingEnv = [];
+  if (!CLIENT_ID) missingEnv.push('EPIC_PROD_CLIENT_ID');
+  if (!KEY_FILE) missingEnv.push('EPIC_PROD_PRIVATE_KEY_FILE');
+  if (!TOKEN_URL) missingEnv.push('EPIC_PROD_TOKEN_URL');
+  if (!FHIR_BASE) missingEnv.push('EPIC_PROD_FHIR_BASE');
+  if (missingEnv.length) {
+    fail(`Missing required environment variables: ${missingEnv.join(', ')}`);
+    console.log('\n\nSee the header of this script for configuration details.\n');
+    process.exit(2);
+  }
+
+  record(`TransTrack Epic production verification`);
+  record(`Run at (UTC): ${new Date().toISOString()}`);
+  record(`Endpoint host: ${redactHost(FHIR_BASE)}`);
+  record(`Client ID: ${CLIENT_ID.slice(0, 8)}… (truncated)`);
+  record('');
+
+  // 1. Token exchange
+  section('1 · Token Exchange (SMART Backend Services)');
+  let client;
+  let tok;
+  try {
+    client = createEpicClientFromKeyFile({
+      clientId: CLIENT_ID,
+      privateKeyFile: KEY_FILE,
+      tokenUrl: TOKEN_URL,
+      fhirBase: FHIR_BASE,
+      kid: KID,
+    });
+    tok = await client.getAccessToken();
+    tick(`Access token obtained (expires in ~${Math.round((tok.expiresAt - Date.now()) / 1000)}s)`);
+    record('Token exchange: OK');
+  } catch (err) {
+    fail(`Token exchange FAILED: ${err.message}`);
+    record(`Token exchange: FAILED — ${err.message}`);
+    writeEvidence(1);
+    process.exit(1);
+  }
+
+  // 2. Scope check
+  section('2 · Scope Check');
+  const grantedScopes = (tok.scope || '').split(/\s+/).filter(Boolean);
+  const requested = DEFAULT_SCOPES.split(' ');
+  const missing = requested.filter((s) => !grantedScopes.includes(s));
+  info(`Granted: ${grantedScopes.length} scope(s); requested: ${requested.length}`);
+  if (missing.length === 0) {
+    tick('All requested scopes granted');
+    record(`Scopes: all ${requested.length} requested scopes granted`);
+  } else {
+    fail(`${missing.length} scope(s) NOT granted: ${missing.join(', ')}`);
+    record(`Scopes: MISSING — ${missing.join(', ')}`);
+  }
+
+  // 3. FHIR metadata
+  section('3 · FHIR Server Metadata');
+  try {
+    const meta = await client.fhirGet('metadata');
+    tick(`FHIR version: ${meta.fhirVersion}`);
+    tick(`Software: ${meta.software?.name || 'unknown'} ${meta.software?.version || ''}`);
+    record(`Metadata: OK — FHIR ${meta.fhirVersion}, ${meta.software?.name || 'unknown'} ${meta.software?.version || ''}`);
+  } catch (err) {
+    fail(`Metadata fetch failed: ${err.message}`);
+    record(`Metadata: FAILED — ${err.message}`);
+  }
+
+  // 4. Optional patient pull (counts only — no PHI persisted)
+  if (TEST_PATIENT) {
+    section('4 · Patient Bundle Fetch (counts only)');
+    try {
+      const bundle = await client.fetchPatientBundle(TEST_PATIENT);
+      tick(`Patient resource fetched (id supplied via env; details not persisted)`);
+      info(`Observations: ${bundle.observations.length}`);
+      info(`Conditions: ${bundle.conditions.length}`);
+      info(`MedicationRequests: ${bundle.medicationRequests.length}`);
+      info(`AllergyIntolerances: ${bundle.allergies.length}`);
+      record(
+        `Patient pull: OK — obs=${bundle.observations.length} cond=${bundle.conditions.length} ` +
+        `meds=${bundle.medicationRequests.length} allergies=${bundle.allergies.length}`
+      );
+    } catch (err) {
+      fail(`Patient bundle fetch FAILED: ${err.message}`);
+      record(`Patient pull: FAILED — ${err.message}`);
+      writeEvidence(1);
+      process.exit(1);
+    }
+  } else {
+    section('4 · Patient Bundle Fetch');
+    info('Skipped (EPIC_PROD_TEST_PATIENT not set — connectivity verified without touching PHI)');
+    record('Patient pull: skipped (no test patient configured)');
+  }
+
+  section('Summary');
+  tick('Production verification complete');
+  writeEvidence(0);
+  console.log('\n');
+}
+
+function writeEvidence(exitCode) {
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, '').replace('T', '-');
+  const dir = path.join(__dirname, '..', 'demo-evidence');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `epic-production-${stamp}.txt`);
+  record('');
+  record(`Exit code: ${exitCode}`);
+  fs.writeFileSync(file, evidence.join('\n') + '\n', 'utf8');
+  console.log(`\n\n  Evidence written to ${file}`);
+}
+
+run().catch((err) => {
+  console.error('\nFatal:', err.message);
+  record(`Fatal: ${err.message}`);
+  writeEvidence(1);
+  process.exit(1);
+});

--- a/scripts/epic-production-check.mjs
+++ b/scripts/epic-production-check.mjs
@@ -48,7 +48,13 @@ function info(label) { process.stdout.write(`\n  \x1b[36m·\x1b[0m ${label}`); }
 function section(title) { console.log(`\n\x1b[1m\x1b[34m── ${title} ──\x1b[0m`); }
 
 const evidence = [];
-function record(line) { evidence.push(line); }
+// Evidence lines may embed fragments of HTTP error responses; strip control
+// characters and cap length so a hostile/misconfigured endpoint cannot
+// inject arbitrary content into the evidence file.
+function record(line) {
+  const clean = String(line).replace(/[^\x20-\x7E]/g, ' ').slice(0, 500);
+  evidence.push(clean);
+}
 
 function redactHost(url) {
   try {

--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -1,0 +1,56 @@
+/**
+ * Self-contained ESLint flat config for the TransTrack server package.
+ *
+ * The server is linted standalone in CI (only server/ dependencies are
+ * installed), so this config must not rely on the repository-root
+ * eslint.config.js or root node_modules.
+ */
+import globals from 'globals';
+import pluginJs from '@eslint/js';
+
+export default [
+  {
+    files: ['src/**/*.js', 'test/**/*.{js,mjs}'],
+    ...pluginJs.configs.recommended,
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'commonjs',
+      },
+    },
+    rules: {
+      'no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          varsIgnorePattern: '^_',
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      'no-throw-literal': 'error',
+      'no-cond-assign': ['error', 'always'],
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      // `== null` / `!= null` is the intentional null-or-undefined idiom
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'no-with': 'error',
+      'no-dupe-keys': 'error',
+      'no-unreachable': 'error',
+      'valid-typeof': 'error',
+    },
+  },
+  {
+    files: ['test/**/*.mjs', 'src/**/*.mjs'],
+    languageOptions: {
+      parserOptions: {
+        sourceType: 'module',
+      },
+    },
+  },
+];

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -39,6 +39,31 @@
         "stripe": "^18.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^10.0.2",
         "@fastify/formbody": "^8.0.2",
         "@fastify/helmet": "^12.0.1",
@@ -36,31 +37,6 @@
       "optionalDependencies": {
         "nodemailer": "^9.0.1",
         "stripe": "^18.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -259,6 +235,55 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/cookie": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.1.2.tgz",
+      "integrity": "sha512-Dtrpk/YOGUsbRMvP/8ZqPpwnMRv0qSqodFdoQ2B589Obc7jw4s4Qla+cV72Bsm7WsZJnqlYFX/i7uSBq0xzg6g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^2.0.0",
+        "fastify-plugin": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/cookie/node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@fastify/cookie/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/@fastify/cors": {
@@ -1186,6 +1211,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1744,6 +1770,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3266,6 +3293,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -3363,6 +3391,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4221,6 +4250,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint src test --max-warnings=0"
   },
   "dependencies": {
+    "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.0.2",
     "@fastify/formbody": "^8.0.2",
     "@fastify/helmet": "^12.0.1",

--- a/server/src/auth/sessionCookies.js
+++ b/server/src/auth/sessionCookies.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const REFRESH_COOKIE = 'transtrack_refresh';
+const ACCESS_COOKIE = 'transtrack_access';
+
+function cookieBase(config) {
+  return {
+    httpOnly: true,
+    secure: config.NODE_ENV === 'production',
+    sameSite: 'Lax',
+  };
+}
+
+function setSessionCookies(reply, { access, refresh, config }) {
+  const base = cookieBase(config);
+  if (refresh) {
+    reply.setCookie(REFRESH_COOKIE, refresh, {
+      ...base,
+      path: '/auth',
+      maxAge: config.JWT_REFRESH_TTL_SECONDS,
+    });
+  }
+  if (access) {
+    reply.setCookie(ACCESS_COOKIE, access, {
+      ...base,
+      path: '/',
+      maxAge: config.JWT_ACCESS_TTL_SECONDS,
+    });
+  }
+}
+
+function clearSessionCookies(reply) {
+  reply.clearCookie(REFRESH_COOKIE, { path: '/auth' });
+  reply.clearCookie(ACCESS_COOKIE, { path: '/' });
+}
+
+function readRefreshToken(req, bodyRefresh) {
+  return bodyRefresh || req.cookies?.[REFRESH_COOKIE] || null;
+}
+
+function readAccessToken(req) {
+  const header = req.headers.authorization || '';
+  if (header.toLowerCase().startsWith('bearer ')) {
+    const raw = header.slice(header.indexOf(' ') + 1).trim();
+    if (raw) return raw;
+  }
+  return req.cookies?.[ACCESS_COOKIE] || null;
+}
+
+module.exports = {
+  REFRESH_COOKIE,
+  ACCESS_COOKIE,
+  setSessionCookies,
+  clearSessionCookies,
+  readRefreshToken,
+  readAccessToken,
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const Fastify = require('fastify');
 const cors = require('@fastify/cors');
+const cookie = require('@fastify/cookie');
 const helmet = require('@fastify/helmet');
 const sensible = require('@fastify/sensible');
 const rateLimit = require('@fastify/rate-limit');
@@ -64,6 +65,11 @@ async function build() {
         }
       : config.NODE_ENV === 'development',
     credentials: true,
+  });
+  await app.register(cookie, {
+    secret: config.JWT_SECRET,
+    hook: 'onRequest',
+    parseOptions: {},
   });
   await app.register(helmet, {
     contentSecurityPolicy: false, // SPA-served separately; FHIR clients break with strict CSP

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -3,6 +3,7 @@
 const jwt = require('../auth/jwt');
 const smartTokens = require('../smart/tokens');
 const smartScopes = require('../smart/scopes');
+const { readAccessToken } = require('../auth/sessionCookies');
 const { errors } = require('../util/errors');
 
 /**
@@ -27,10 +28,11 @@ function makeAuthHook(config) {
       await req.rateLimit();
     }
     const header = req.headers['authorization'] || '';
-    if (!header.toLowerCase().startsWith('bearer ')) {
-      throw errors.unauthorized('Missing Bearer token');
+    let raw = '';
+    if (header.toLowerCase().startsWith('bearer ')) {
+      raw = header.slice(header.indexOf(' ') + 1).trim();
     }
-    const raw = header.slice(header.indexOf(' ') + 1).trim();
+    if (!raw) raw = readAccessToken(req) || '';
     if (!raw) throw errors.unauthorized('Missing Bearer token');
 
     // Heuristic: native JWT contains exactly two dots and base64url segments;
@@ -85,14 +87,8 @@ function makeAuthHook(config) {
 function requireRole(...allowed) {
   return async function (req) {
     if (!req.auth) throw errors.unauthorized();
-    // SMART system tokens (backend services) act as 'admin' for purposes of
-    // RBAC — scope-based filtering is the actual access-control mechanism.
-    if (req.auth.role === 'smart_system') return;
-    if (req.auth.role === 'smart_user') {
-      // For SMART user tokens, treat as 'user' unless the calling route
-      // permits it explicitly (e.g. routes that require 'admin' will deny).
-      if (allowed.includes('user') || allowed.includes('smart_user')) return;
-      throw errors.forbidden('SMART user token cannot access role-restricted endpoint');
+    if (req.auth.role === 'smart_system' || req.auth.role === 'smart_user') {
+      throw errors.forbidden('SMART tokens cannot access native API endpoints');
     }
     if (!allowed.includes(req.auth.role) && req.auth.role !== 'admin') {
       throw errors.forbidden(`Requires one of: ${allowed.join(', ')}`);

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -8,34 +8,42 @@ const mfa = require('../auth/mfa');
 const samlMod = require('../auth/saml');
 const oidcMod = require('../auth/oidc');
 const { errors } = require('../util/errors');
+const { setSessionCookies, clearSessionCookies, readRefreshToken } = require('../auth/sessionCookies');
 
 module.exports = async function authRoutes(app, opts) {
   const { config } = opts;
 
   // ----- POST /auth/login (local password) -----
-  app.post('/auth/login', { config: { public: true, rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (req) => {
+  app.post('/auth/login', { config: { public: true, rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (req, reply) => {
     const body = z.object({
       email: z.string().email(),
       password: z.string().min(1),
     }).parse(req.body);
-    return withTransaction({}, async (client) => {
-      const result = await authService.passwordLogin(client, config, {
+    const result = await withTransaction({}, async (client) => {
+      return authService.passwordLogin(client, config, {
         email: body.email,
         plaintext: body.password,
         ip: req.ip,
         userAgent: req.headers['user-agent'],
       });
-      return result;
     });
+    if (result.kind === 'session') {
+      setSessionCookies(reply, {
+        access: result.access,
+        refresh: result.refresh,
+        config,
+      });
+    }
+    return result;
   });
 
   // ----- POST /auth/mfa/verify -----
-  app.post('/auth/mfa/verify', { config: { public: true, rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (req) => {
+  app.post('/auth/mfa/verify', { config: { public: true, rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (req, reply) => {
     const body = z.object({
       challengeId: z.string().uuid(),
       code: z.string().min(6).max(20),
     }).parse(req.body);
-    return withTransaction({}, async (client) => {
+    const result = await withTransaction({}, async (client) => {
       return authService.consumeMfaChallenge(client, config, {
         challengeId: body.challengeId,
         code: body.code,
@@ -43,26 +51,44 @@ module.exports = async function authRoutes(app, opts) {
         userAgent: req.headers['user-agent'],
       });
     });
+    if (result.kind === 'session') {
+      setSessionCookies(reply, {
+        access: result.access,
+        refresh: result.refresh,
+        config,
+      });
+    }
+    return result;
   });
 
   // ----- POST /auth/refresh -----
-  app.post('/auth/refresh', { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (req) => {
-    const body = z.object({ refresh: z.string().min(10) }).parse(req.body);
-    return withTransaction({}, async (client) => {
+  app.post('/auth/refresh', { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (req, reply) => {
+    const body = z.object({ refresh: z.string().min(10).optional() }).parse(req.body || {});
+    const refreshToken = readRefreshToken(req, body.refresh);
+    if (!refreshToken) throw errors.unauthorized('Missing refresh token');
+    const result = await withTransaction({}, async (client) => {
       return authService.refresh(client, config, {
-        refreshToken: body.refresh,
+        refreshToken,
         ip: req.ip,
         userAgent: req.headers['user-agent'],
       });
     });
+    setSessionCookies(reply, {
+      access: result.access,
+      refresh: result.refresh,
+      config,
+    });
+    return result;
   });
 
   // ----- POST /auth/logout -----
-  app.post('/auth/logout', { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (req) => {
+  app.post('/auth/logout', { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } }, async (req, reply) => {
     const body = z.object({ refresh: z.string().optional() }).parse(req.body || {});
+    const refreshToken = readRefreshToken(req, body.refresh);
     await withTransaction({}, async (client) => {
-      await authService.revoke(client, body.refresh);
+      await authService.revoke(client, refreshToken);
     });
+    clearSessionCookies(reply);
     return { ok: true };
   });
 

--- a/server/src/routes/smart.js
+++ b/server/src/routes/smart.js
@@ -31,6 +31,7 @@ const tokens = require('../smart/tokens');
 const authzCodes = require('../smart/authzCodes');
 const clients = require('../smart/clients');
 const backendJwt = require('../smart/backendJwt');
+const { authenticateOAuthClient } = require('../smart/clientAuth');
 
 module.exports = async function smartRoutes(app, opts) {
   const { config } = opts;
@@ -56,6 +57,12 @@ module.exports = async function smartRoutes(app, opts) {
         registration_endpoint: `${issuer}/oauth2/register`,
         introspection_endpoint: `${issuer}/oauth2/introspect`,
         revocation_endpoint: `${issuer}/oauth2/revoke`,
+        introspection_endpoint_auth_methods_supported: [
+          'client_secret_basic', 'client_secret_post', 'private_key_jwt',
+        ],
+        revocation_endpoint_auth_methods_supported: [
+          'client_secret_basic', 'client_secret_post', 'private_key_jwt',
+        ],
         scopes_supported: [
           'openid', 'fhirUser', 'profile', 'email',
           'launch', 'launch/patient', 'launch/encounter', 'launch/practitioner',
@@ -376,9 +383,11 @@ module.exports = async function smartRoutes(app, opts) {
   app.post('/oauth2/introspect',
     { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
     async (req) => {
-      const data = z.object({ token: z.string().min(1) }).parse(req.body || {});
+      const body = req.body || {};
+      const { clientId } = await authenticateOAuthClient(req, body, { tokenUrl });
+      const data = z.object({ token: z.string().min(1) }).parse(body);
       const found = await tokens.lookupAccess(data.token);
-      if (!found) return { active: false };
+      if (!found || found.clientId !== clientId) return { active: false };
       return {
         active: true,
         scope: found.scope,
@@ -392,8 +401,13 @@ module.exports = async function smartRoutes(app, opts) {
   app.post('/oauth2/revoke',
     { config: { public: true, rateLimit: { max: 30, timeWindow: '1 minute' } } },
     async (req, reply) => {
-      const data = z.object({ token: z.string().min(1) }).parse(req.body || {});
-      await tokens.revoke(data.token);
+      const body = req.body || {};
+      const { clientId } = await authenticateOAuthClient(req, body, { tokenUrl });
+      const data = z.object({ token: z.string().min(1) }).parse(body);
+      const ownerClientId = await tokens.lookupTokenClientId(data.token);
+      if (ownerClientId && ownerClientId === clientId) {
+        await tokens.revoke(data.token);
+      }
       reply.code(200).send({ revoked: true });
     });
 };

--- a/server/src/routes/smart.js
+++ b/server/src/routes/smart.js
@@ -25,8 +25,7 @@
 const { z } = require('zod');
 const { errors } = require('../util/errors');
 const { requireRole } = require('../middleware/auth');
-const { withTransaction, getPool } = require('../db/pool');
-const scopes = require('../smart/scopes');
+const { getPool } = require('../db/pool');
 const tokens = require('../smart/tokens');
 const authzCodes = require('../smart/authzCodes');
 const clients = require('../smart/clients');

--- a/server/src/services/authService.js
+++ b/server/src/services/authService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { newId, newToken, sha256 } = require('../util/ids');
+const { newToken, sha256 } = require('../util/ids');
 const password = require('../auth/password');
 const mfa = require('../auth/mfa');
 const jwt = require('../auth/jwt');

--- a/server/src/smart/clientAuth.js
+++ b/server/src/smart/clientAuth.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { errors } = require('../util/errors');
+const clients = require('./clients');
+const backendJwt = require('./backendJwt');
+
+/**
+ * Parse OAuth client credentials from Authorization: Basic or request body.
+ */
+function parseClientCredentials(req, body = {}) {
+  let basicClientId = null;
+  let basicSecret = null;
+  const auth = req.headers.authorization || '';
+  if (auth.toLowerCase().startsWith('basic ')) {
+    const decoded = Buffer.from(auth.slice(6).trim(), 'base64').toString('utf8');
+    const colon = decoded.indexOf(':');
+    if (colon > 0) {
+      basicClientId = decoded.slice(0, colon);
+      basicSecret = decoded.slice(colon + 1);
+    }
+  }
+  return {
+    clientId: body.client_id || basicClientId,
+    clientSecret: body.client_secret || basicSecret,
+    clientAssertion: body.client_assertion,
+    clientAssertionType: body.client_assertion_type,
+  };
+}
+
+/**
+ * Authenticate an OAuth client for introspection/revocation (RFC 7662 / RFC 7009).
+ */
+async function authenticateOAuthClient(req, body, { tokenUrl } = {}) {
+  const { clientId, clientSecret, clientAssertion, clientAssertionType } =
+    parseClientCredentials(req, body);
+  if (!clientId) throw errors.unauthorized('client authentication required');
+
+  const smartClient = await clients.getUnscoped(clientId);
+  if (!smartClient) throw errors.unauthorized('invalid_client');
+
+  if (smartClient.client_type === 'confidential') {
+    const ok = await clients.verifySecret(smartClient, clientSecret);
+    if (!ok) throw errors.unauthorized('invalid_client');
+  } else if (smartClient.client_type === 'backend') {
+    if (
+      clientAssertion
+      && clientAssertionType === 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+      && tokenUrl
+    ) {
+      await backendJwt.verifyAssertion(smartClient, clientAssertion, tokenUrl);
+    } else if (clientSecret) {
+      const ok = await clients.verifySecret(smartClient, clientSecret);
+      if (!ok) throw errors.unauthorized('invalid_client');
+    } else {
+      // Backend services must present a private_key_jwt assertion or a secret;
+      // a bare client_id is not authentication.
+      throw errors.unauthorized('client authentication required');
+    }
+  }
+
+  return { clientId, smartClient };
+}
+
+module.exports = { parseClientCredentials, authenticateOAuthClient };

--- a/server/src/smart/clientAuth.js
+++ b/server/src/smart/clientAuth.js
@@ -27,8 +27,18 @@ function parseClientCredentials(req, body = {}) {
   };
 }
 
+const JWT_BEARER_ASSERTION_TYPE =
+  'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
 /**
  * Authenticate an OAuth client for introspection/revocation (RFC 7662 / RFC 7009).
+ *
+ * Exactly one verification path exists per registered client type — the
+ * caller cannot select a weaker path by shaping the request:
+ *   confidential -> client secret (Basic or client_secret_post), always verified
+ *   backend      -> private_key_jwt assertion, always verified
+ *   anything else (public/unknown) -> rejected; public clients cannot
+ *                   authenticate and are not permitted on these endpoints
  */
 async function authenticateOAuthClient(req, body, { tokenUrl } = {}) {
   const { clientId, clientSecret, clientAssertion, clientAssertionType } =
@@ -42,20 +52,12 @@ async function authenticateOAuthClient(req, body, { tokenUrl } = {}) {
     const ok = await clients.verifySecret(smartClient, clientSecret);
     if (!ok) throw errors.unauthorized('invalid_client');
   } else if (smartClient.client_type === 'backend') {
-    if (
-      clientAssertion
-      && clientAssertionType === 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-      && tokenUrl
-    ) {
-      await backendJwt.verifyAssertion(smartClient, clientAssertion, tokenUrl);
-    } else if (clientSecret) {
-      const ok = await clients.verifySecret(smartClient, clientSecret);
-      if (!ok) throw errors.unauthorized('invalid_client');
-    } else {
-      // Backend services must present a private_key_jwt assertion or a secret;
-      // a bare client_id is not authentication.
+    if (!tokenUrl || clientAssertionType !== JWT_BEARER_ASSERTION_TYPE || !clientAssertion) {
       throw errors.unauthorized('client authentication required');
     }
+    await backendJwt.verifyAssertion(smartClient, clientAssertion, tokenUrl);
+  } else {
+    throw errors.unauthorized('invalid_client');
   }
 
   return { clientId, smartClient };

--- a/server/src/smart/tokens.js
+++ b/server/src/smart/tokens.js
@@ -111,6 +111,16 @@ async function refresh(rawRefresh, { ttlSeconds = 3600 } = {}) {
   });
 }
 
+async function lookupTokenClientId(rawToken) {
+  const h = hash(rawToken);
+  const r = await getPool().query(
+    `SELECT client_id FROM smart_access_tokens
+     WHERE access_token_hash = $1 OR refresh_token_hash = $1`,
+    [h]
+  );
+  return r.rows[0]?.client_id || null;
+}
+
 async function revoke(rawToken) {
   await getPool().query(
     `UPDATE smart_access_tokens SET revoked_at = now()
@@ -119,4 +129,6 @@ async function revoke(rawToken) {
   );
 }
 
-module.exports = { issue, lookupAccess, refresh, revoke, hash, newOpaque };
+module.exports = {
+  issue, lookupAccess, lookupTokenClientId, refresh, revoke, hash, newOpaque,
+};

--- a/server/test/unit/authRoles.test.mjs
+++ b/server/test/unit/authRoles.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { requireRole } = require('../../src/middleware/auth');
+
+describe('requireRole', () => {
+  it('denies SMART system tokens on native API routes', async () => {
+    const handler = requireRole('admin', 'coordinator');
+    const req = { auth: { role: 'smart_system', tokenType: 'smart' } };
+    await expect(handler(req)).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('denies SMART user tokens on native API routes', async () => {
+    const handler = requireRole('admin', 'coordinator');
+    const req = { auth: { role: 'smart_user', tokenType: 'smart' } };
+    await expect(handler(req)).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('allows native admin role', async () => {
+    const handler = requireRole('admin', 'coordinator');
+    const req = { auth: { role: 'admin', tokenType: 'jwt' } };
+    await expect(handler(req)).resolves.toBeUndefined();
+  });
+
+  it('allows matching native role', async () => {
+    const handler = requireRole('coordinator', 'physician');
+    const req = { auth: { role: 'coordinator', tokenType: 'jwt' } };
+    await expect(handler(req)).resolves.toBeUndefined();
+  });
+});

--- a/server/test/unit/smartClientAuth.test.mjs
+++ b/server/test/unit/smartClientAuth.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { parseClientCredentials } = require('../../src/smart/clientAuth');
+
+describe('parseClientCredentials', () => {
+  it('extracts client_id and secret from Basic auth', () => {
+    const secret = Buffer.from('my-client:super-secret').toString('base64');
+    const req = { headers: { authorization: `Basic ${secret}` } };
+    const creds = parseClientCredentials(req, {});
+    expect(creds.clientId).toBe('my-client');
+    expect(creds.clientSecret).toBe('super-secret');
+  });
+
+  it('prefers body client_id over Basic auth username', () => {
+    const basic = Buffer.from('ignored:pw').toString('base64');
+    const req = { headers: { authorization: `Basic ${basic}` } };
+    const creds = parseClientCredentials(req, { client_id: 'body-client', client_secret: 'body-secret' });
+    expect(creds.clientId).toBe('body-client');
+    expect(creds.clientSecret).toBe('body-secret');
+  });
+
+  it('returns null clientId when no credentials present', () => {
+    const creds = parseClientCredentials({ headers: {} }, {});
+    expect(creds.clientId).toBeFalsy();
+  });
+});

--- a/src/api/localClient.js
+++ b/src/api/localClient.js
@@ -290,10 +290,38 @@ const mockClient = {
     }),
     getRequiredTypes: async () => [],
   },
+  files: {
+    importFile: async () => null,
+    exportCSV: async () => ({ success: false, reason: 'Not available outside Electron' }),
+    exportExcel: async () => ({ success: false, reason: 'Not available outside Electron' }),
+    exportPDF: async () => ({ success: false, reason: 'Not available outside Electron' }),
+  },
   risk: {
     getDashboard: async () => ({ riskScore: 0, patients: [], alerts: [] }),
     getFullReport: async () => ({ report: {} }),
     assessPatient: async () => ({ riskLevel: 'low' }),
+  },
+  actionQueue: {
+    build: async () => ({
+      queueVersion: 'dev', modelVersion: 'dev', generatedAtISO: new Date().toISOString(),
+      candidatesScreened: 0, queueSize: 0,
+      distribution: { critical: 0, high: 0, moderate: 0, low: 0, none: 0 },
+      queue: [], coordinatorOverloads: [],
+      aggregateExpectedImpact: {
+        projectedProbabilityReductionWithin90Days: 0,
+        projectedInactivationsAvoidedWithin90Days: 0,
+      },
+      disclaimer: 'Dev placeholder — not available outside Electron.',
+    }),
+    topInterventionsForPatient: async () => ({ topInterventions: [] }),
+    recordIntervention: async () => ({ id: null }),
+    recordOutcome: async () => ({ updated: false }),
+    getInterventionsForPatient: async () => [],
+    getInterventionEffectiveness: async () => ({
+      windowDays: 90, perInterventionType: [],
+      totals: { recorded: 0, measured: 0, weightedAvgScoreDelta: 0, weightedAvgProb90Delta: 0 },
+    }),
+    buildDigest: async () => null,
   },
   outcomes: {
     getDashboard: async () => ({ outcomes: [] }),
@@ -638,11 +666,36 @@ const createElectronClient = () => {
         return typeof unsubscribe === 'function' ? unsubscribe : () => {};
       },
     },
+    // File import/export (native dialogs; audit-logged in the main process)
+    files: {
+      importFile: async (type) => await window.electronAPI.files.importFile(type),
+      exportCSV: async (data, filename) => await window.electronAPI.files.exportCSV(data, filename),
+      exportExcel: async (data, filename) => await window.electronAPI.files.exportExcel(data, filename),
+      exportPDF: async (data, filename) => await window.electronAPI.files.exportPDF(data, filename),
+    },
     // Risk Intelligence
     risk: {
       getDashboard: async () => await window.electronAPI.risk.getDashboard(),
       getFullReport: async () => await window.electronAPI.risk.getFullReport(),
       assessPatient: async (patientId) => await window.electronAPI.risk.assessPatient(patientId),
+    },
+    // Inactivation Prevention Action Queue + measured outcomes.
+    // Ranked coordinator worklist built by the deterministic risk engine,
+    // with recorded interventions and measured before/after outcomes.
+    actionQueue: {
+      build: async (opts) => await window.electronAPI.actionQueue.build(opts),
+      topInterventionsForPatient: async (params) =>
+        await window.electronAPI.actionQueue.topInterventionsForPatient(params),
+      recordIntervention: async (params) =>
+        await window.electronAPI.actionQueue.recordIntervention(params),
+      recordOutcome: async (params) =>
+        await window.electronAPI.actionQueue.recordOutcome(params),
+      getInterventionsForPatient: async (params) =>
+        await window.electronAPI.actionQueue.getInterventionsForPatient(params),
+      getInterventionEffectiveness: async (params) =>
+        await window.electronAPI.actionQueue.getInterventionEffectiveness(params),
+      buildDigest: async (params) =>
+        await window.electronAPI.actionQueue.buildDigest(params),
     },
     // Outcomes Dashboard
     outcomes: {
@@ -695,8 +748,38 @@ const createElectronClient = () => {
   };
 };
 
+/**
+ * Production guard: a clinical product must never silently serve fabricated
+ * data. If the Electron IPC bridge is missing in a production build (and the
+ * remote API client isn't active — see apiClient.js), every call fails loudly
+ * with a diagnosable error instead of returning placeholder values.
+ * The mock client is reachable only in dev builds and test environments.
+ */
+const productionGuardClient = new Proxy({}, {
+  get(_target, namespace) {
+    if (namespace === 'then') return undefined;
+    return new Proxy({}, {
+      get(_t, method) {
+        return () => {
+          throw new Error(
+            `TransTrack data bridge unavailable (api.${String(namespace)}.${String(method)}). ` +
+            'The Electron IPC bridge failed to initialize and no remote API is configured. ' +
+            'Refusing to serve placeholder data in a production build — restart the ' +
+            'application; if the problem persists, contact support.'
+          );
+        };
+      },
+    });
+  },
+});
+
+const isProductionBuild =
+  typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.PROD === true;
+
 // Export the appropriate client
-export const localClient = isElectron ? createElectronClient() : mockClient;
+export const localClient = isElectron
+  ? createElectronClient()
+  : (isProductionBuild ? productionGuardClient : mockClient);
 
 // Default export for compatibility
 export default localClient;

--- a/src/api/remoteClient.js
+++ b/src/api/remoteClient.js
@@ -4,33 +4,38 @@
  * Used when the Electron renderer (or a pure web build) is configured to
  * speak to a TransTrack API server instead of the local SQLite + IPC bridge.
  *
+ * Session tokens:
+ *   - Access token: held in memory only (never localStorage).
+ *   - Refresh token: httpOnly cookie set by the server (credentials: include).
+ *
  * Activation:
  *   - In Electron, set TRANSTRACK_API_URL via the user's preferences or
  *     pass it through `window.transtrackConfig.apiBaseUrl`.
  *   - In a web build, define VITE_TRANSTRACK_API_URL at build time.
- *
- * The exported shape intentionally mirrors `localClient` for the subset of
- * functionality currently routed through the API.  Anything not yet wired
- * to a REST endpoint falls through to a local-IPC implementation when
- * available, otherwise throws a clear error.
  */
 
-const ACCESS_KEY = 'transtrack:access';
-const REFRESH_KEY = 'transtrack:refresh';
+const LEGACY_ACCESS_KEY = 'transtrack:access';
+const LEGACY_REFRESH_KEY = 'transtrack:refresh';
+
+/** @type {string | null} */
+let memoryAccessToken = null;
+
+function purgeLegacyLocalStorage() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(LEGACY_ACCESS_KEY);
+  localStorage.removeItem(LEGACY_REFRESH_KEY);
+}
+
+purgeLegacyLocalStorage();
 
 function tokenStore() {
   return {
-    getAccess: () => (typeof localStorage !== 'undefined' ? localStorage.getItem(ACCESS_KEY) : null),
-    getRefresh: () => (typeof localStorage !== 'undefined' ? localStorage.getItem(REFRESH_KEY) : null),
-    set: (access, refresh) => {
-      if (typeof localStorage === 'undefined') return;
-      if (access) localStorage.setItem(ACCESS_KEY, access);
-      if (refresh) localStorage.setItem(REFRESH_KEY, refresh);
+    getAccess: () => memoryAccessToken,
+    setAccess: (access) => {
+      memoryAccessToken = access || null;
     },
     clear: () => {
-      if (typeof localStorage === 'undefined') return;
-      localStorage.removeItem(ACCESS_KEY);
-      localStorage.removeItem(REFRESH_KEY);
+      memoryAccessToken = null;
     },
   };
 }
@@ -49,6 +54,7 @@ class RemoteClient {
     const r = await fetch(url, {
       method: opts.method || 'GET',
       headers,
+      credentials: 'include',
       body: opts.body ? JSON.stringify(opts.body) : undefined,
     });
     if (r.status === 401 && access && opts._retry !== true) {
@@ -71,17 +77,16 @@ class RemoteClient {
   }
 
   async _refresh() {
-    const refresh = this.tokens.getRefresh();
-    if (!refresh) return false;
     try {
       const r = await fetch(this.baseUrl + '/auth/refresh', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ refresh }),
+        credentials: 'include',
+        body: JSON.stringify({}),
       });
       if (!r.ok) { this.tokens.clear(); return false; }
       const body = await r.json();
-      this.tokens.set(body.access, body.refresh);
+      this.tokens.setAccess(body.access);
       return true;
     } catch {
       this.tokens.clear();
@@ -93,17 +98,16 @@ class RemoteClient {
   auth = {
     login: async ({ email, password }) => {
       const r = await this._fetch('/auth/login', { method: 'POST', body: { email, password } });
-      if (r.kind === 'session') this.tokens.set(r.access, r.refresh);
+      if (r.kind === 'session') this.tokens.setAccess(r.access);
       return r;
     },
     loginMfa: async ({ challengeId, code }) => {
       const r = await this._fetch('/auth/mfa/verify', { method: 'POST', body: { challengeId, code } });
-      if (r.kind === 'session') this.tokens.set(r.access, r.refresh);
+      if (r.kind === 'session') this.tokens.setAccess(r.access);
       return r;
     },
     logout: async () => {
-      const refresh = this.tokens.getRefresh();
-      try { await this._fetch('/auth/logout', { method: 'POST', body: { refresh } }); }
+      try { await this._fetch('/auth/logout', { method: 'POST', body: {} }); }
       finally { this.tokens.clear(); }
       return { ok: true };
     },

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -4,7 +4,7 @@ import { createPageUrl } from '@/utils';
 import {
   Activity, Users, FileText, Settings, Shield, Heart, Database,
   AlertTriangle, HardDrive, BarChart3, Brain, ListTodo, ClipboardCheck,
-  Stethoscope, Inbox, KeyRound, UserPlus, X, Key,
+  Stethoscope, Inbox, KeyRound, UserPlus, X, Key, ListChecks,
 } from 'lucide-react';
 
 /**
@@ -61,6 +61,7 @@ export default function Sidebar({ user, isOpen = true, onClose }) {
       items: [
         { name: 'Reports', page: 'Reports', icon: FileText, show: true },
         { name: 'Tasks', page: 'TaskCenter', icon: ListTodo, show: isClinicalStaff },
+        { name: 'Prevention Queue', page: 'PreventionQueue', icon: ListChecks, show: isClinicalStaff },
         { name: 'Risk Intel', page: 'RiskDashboard', icon: AlertTriangle, show: isClinicalStaff },
         { name: 'Predictive', page: 'PredictiveRisk', icon: Brain, show: isClinicalStaff },
         { name: 'Outcomes', page: 'OutcomesDashboard', icon: BarChart3, show: isAdmin },

--- a/src/pages.config.js
+++ b/src/pages.config.js
@@ -20,6 +20,7 @@ import PostTransplant from './pages/PostTransplant';
 import LivingDonors from './pages/LivingDonors';
 import Hl7Inbox from './pages/Hl7Inbox';
 import License from './pages/License';
+import PreventionQueue from './pages/PreventionQueue';
 import __Layout from './Layout.jsx';
 
 
@@ -46,6 +47,7 @@ export const PAGES = {
     "LivingDonors": LivingDonors,
     "Hl7Inbox": Hl7Inbox,
     "License": License,
+    "PreventionQueue": PreventionQueue,
 }
 
 export const pagesConfig = {

--- a/src/pages/Patients.jsx
+++ b/src/pages/Patients.jsx
@@ -4,15 +4,29 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Plus, Users, Loader2, AlertCircle } from 'lucide-react';
+import { Plus, Users, Loader2, AlertCircle, Upload, CheckCircle2 } from 'lucide-react';
 import ErrorState from '@/components/ui/ErrorState';
 import PatientForm from '../components/patients/PatientForm';
 import { motion, AnimatePresence } from 'framer-motion';
+
+// Columns accepted from a roster CSV (see assets/sample-imports/
+// patient-roster-template.csv). Unknown columns are ignored so exports from
+// other systems can be imported without pre-cleaning.
+const IMPORTABLE_FIELDS = [
+  'patient_id', 'first_name', 'last_name', 'date_of_birth', 'blood_type',
+  'organ_needed', 'medical_urgency', 'waitlist_status',
+  'date_added_to_waitlist', 'last_evaluation_date',
+  'meld_score', 'pra_percentage', 'cpra_percentage',
+  'phone', 'email', 'diagnosis', 'notes',
+];
+const NUMERIC_IMPORT_FIELDS = new Set(['meld_score', 'pra_percentage', 'cpra_percentage']);
 
 export default function Patients() {
   const [showForm, setShowForm] = useState(false);
   const [editingPatient, setEditingPatient] = useState(null);
   const [error, setError] = useState(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importSummary, setImportSummary] = useState(null);
   const queryClient = useQueryClient();
 
   const { data: patients = [], isLoading, isError, error: queryError } = useQuery({
@@ -94,6 +108,66 @@ export default function Patients() {
     setShowForm(true);
   };
 
+  const handleImportCsv = async () => {
+    setIsImporting(true);
+    setError(null);
+    setImportSummary(null);
+    try {
+      const result = await api.files.importFile('csv');
+      if (!result || result.cancelled) return;
+      if (!result.success || !Array.isArray(result.data)) {
+        throw new Error('Import failed: the file could not be parsed.');
+      }
+
+      let created = 0;
+      const failures = [];
+      for (const [i, row] of result.data.entries()) {
+        const payload = {};
+        for (const field of IMPORTABLE_FIELDS) {
+          const value = row[field];
+          if (value === undefined || value === null || String(value).trim() === '') continue;
+          if (NUMERIC_IMPORT_FIELDS.has(field)) {
+            const num = Number(value);
+            if (!Number.isFinite(num)) {
+              failures.push(`Row ${i + 2}: ${field} must be a number (got "${value}")`);
+              continue;
+            }
+            payload[field] = num;
+          } else {
+            payload[field] = String(value).trim();
+          }
+        }
+        if (!payload.first_name || !payload.last_name) {
+          failures.push(`Row ${i + 2}: first_name and last_name are required`);
+          continue;
+        }
+        try {
+          const patient = await api.entities.Patient.create(payload);
+          try {
+            await api.functions.invoke('calculatePriorityAdvanced', { patient_id: patient.id });
+          } catch (e) {
+            // Priority calculation is non-critical, continue
+          }
+          created++;
+        } catch (e) {
+          failures.push(`Row ${i + 2}: ${e.message}`);
+        }
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['patients'] });
+      setImportSummary({
+        filename: result.filename,
+        created,
+        failed: failures.length,
+        failures: failures.slice(0, 5),
+      });
+    } catch (e) {
+      setError(e.message || 'CSV import failed. Please check the file and try again.');
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   const isMutating = createPatientMutation.isPending || updatePatientMutation.isPending;
 
   if (isError) {
@@ -109,19 +183,52 @@ export default function Patients() {
             <p className="text-slate-600 mt-1">Add and manage patient records</p>
           </div>
           {!showForm && (
-            <Button
-              onClick={() => {
-                setEditingPatient(null);
-                setShowForm(true);
-                setError(null);
-              }}
-              className="bg-cyan-600 hover:bg-cyan-700"
-            >
-              <Plus className="w-5 h-5 mr-2" />
-              Add Patient
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={handleImportCsv}
+                disabled={isImporting}
+              >
+                {isImporting ? (
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                ) : (
+                  <Upload className="w-5 h-5 mr-2" />
+                )}
+                Import CSV
+              </Button>
+              <Button
+                onClick={() => {
+                  setEditingPatient(null);
+                  setShowForm(true);
+                  setError(null);
+                }}
+                className="bg-cyan-600 hover:bg-cyan-700"
+              >
+                <Plus className="w-5 h-5 mr-2" />
+                Add Patient
+              </Button>
+            </div>
           )}
         </div>
+
+        {/* Import Summary */}
+        {importSummary && (
+          <Alert className={importSummary.failed > 0 ? 'bg-amber-50 border-amber-200' : 'bg-green-50 border-green-200'}>
+            <CheckCircle2 className="h-4 w-4" />
+            <AlertDescription>
+              Imported {importSummary.created} patient{importSummary.created === 1 ? '' : 's'} from{' '}
+              {importSummary.filename}
+              {importSummary.failed > 0 && (
+                <>
+                  {' '}({importSummary.failed} row{importSummary.failed === 1 ? '' : 's'} skipped):
+                  <ul className="list-disc ml-5 mt-1 text-sm">
+                    {importSummary.failures.map((f, idx) => <li key={idx}>{f}</li>)}
+                  </ul>
+                </>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
 
         {/* Error Display */}
         {(error || queryError) && (

--- a/src/pages/PreventionQueue.jsx
+++ b/src/pages/PreventionQueue.jsx
@@ -1,0 +1,629 @@
+/**
+ * TransTrack — Inactivation Prevention Action Queue.
+ *
+ * Turns the deterministic inactivation risk engine into a coordinator-ready,
+ * ranked worklist:
+ *
+ *   • Queue tab      — highest-priority patients with the single recommended
+ *                      action and its expected score/probability reduction.
+ *   • Outcomes tab   — center-level measured effectiveness per intervention
+ *                      type (recorded vs measured, average score delta).
+ *   • Digest tab     — manager headline: projected inactivations avoided and
+ *                      estimated dollars preserved if the queue is worked.
+ *
+ * Every number is stamped with the engine model version. All data comes from
+ * the audited, org-scoped IPC surface (actionQueue:*).
+ */
+import React, { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  ListChecks, RefreshCw, Info, TrendingDown, Target,
+  ClipboardCheck, Activity, History, CheckCircle2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { createPageUrl } from '@/utils';
+import ErrorState from '@/components/ui/ErrorState';
+import { api } from '@/api/apiClient';
+
+const INTERVENTION_LABELS = {
+  resolveAllBarriers: 'Resolve readiness barriers',
+  resolveBarrier: 'Resolve specific barrier',
+  refreshEvaluation: 'Renew evaluation',
+  refreshDocument: 'Update documentation',
+  refreshLabs: 'Refresh lab documentation',
+  refreshAHHQ: 'Renew aHHQ',
+  recordContact: 'Contact patient',
+  other: 'Other action',
+};
+
+const FACTOR_LABELS = {
+  BARRIERS: 'Readiness barriers',
+  EVAL_EXPIRY: 'Evaluation expiry',
+  DOCUMENTATION: 'Stale documentation',
+  LAB_CURRENCY: 'Lab currency',
+  AHHQ_CURRENCY: 'aHHQ currency',
+  CONTACT_RECENCY: 'Contact recency',
+};
+
+const RISK_BADGE = {
+  critical: 'bg-red-100 text-red-700 border-red-200',
+  high: 'bg-orange-100 text-orange-700 border-orange-200',
+  moderate: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+  low: 'bg-green-100 text-green-700 border-green-200',
+  none: 'bg-slate-100 text-slate-600 border-slate-200',
+};
+
+function pct(v) {
+  if (v === null || v === undefined) return '—';
+  return `${Math.round(v * 1000) / 10}%`;
+}
+
+/** Per-patient intervention history with "measure outcome" for open items. */
+function InterventionHistory({ patientId, onChanged }) {
+  const [measuringId, setMeasuringId] = useState(null);
+  const { data: history, isLoading, refetch } = useQuery({
+    queryKey: ['interventionHistory', patientId],
+    queryFn: () => api.actionQueue.getInterventionsForPatient({ patientId }),
+  });
+
+  const measureOutcome = async (interventionId) => {
+    setMeasuringId(interventionId);
+    try {
+      const r = await api.actionQueue.recordOutcome({ interventionId, patientId });
+      if (r?.updated === false) {
+        toast.error('Intervention not found — it may belong to another organization.');
+      } else {
+        const delta = r?.measured_score_delta;
+        toast.success(
+          delta !== null && delta !== undefined
+            ? `Outcome measured: score reduced by ${delta} points.`
+            : 'Outcome measured.'
+        );
+      }
+      await refetch();
+      onChanged?.();
+    } catch (err) {
+      toast.error(err?.message || 'Failed to record outcome.');
+    } finally {
+      setMeasuringId(null);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500 py-2">Loading intervention history…</div>;
+  }
+  if (!history || history.length === 0) {
+    return <div className="text-sm text-slate-500 py-2">No interventions recorded for this patient yet.</div>;
+  }
+
+  return (
+    <div className="space-y-2 py-2">
+      {history.map((iv) => (
+        <div key={iv.id} className="flex items-center justify-between p-3 bg-white rounded-lg border text-sm">
+          <div>
+            <div className="font-medium text-slate-800">
+              {INTERVENTION_LABELS[iv.intervention_type] || iv.intervention_type}
+              {iv.target_factor && (
+                <span className="text-slate-500 font-normal ml-2">
+                  ({FACTOR_LABELS[iv.target_factor] || iv.target_factor})
+                </span>
+              )}
+            </div>
+            <div className="text-xs text-slate-500 mt-0.5">
+              {iv.performed_by} • {iv.created_at}
+              {iv.notes && <span className="ml-2 italic">“{iv.notes}”</span>}
+            </div>
+            <div className="text-xs text-slate-600 mt-0.5">
+              Score before: <strong>{iv.score_before ?? '—'}</strong>
+              {iv.measured_at ? (
+                <>
+                  {' '}→ after: <strong>{iv.score_after ?? '—'}</strong>
+                  {iv.measured_score_delta !== null && (
+                    <Badge className="ml-2 bg-green-100 text-green-700 border-green-200">
+                      −{iv.measured_score_delta} pts
+                    </Badge>
+                  )}
+                </>
+              ) : null}
+            </div>
+          </div>
+          <div>
+            {iv.measured_at ? (
+              <Badge variant="outline" className="text-green-700 border-green-200 bg-green-50">
+                <CheckCircle2 className="w-3 h-3 mr-1" /> Measured
+              </Badge>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={measuringId === iv.id}
+                onClick={() => measureOutcome(iv.id)}
+              >
+                {measuringId === iv.id ? 'Measuring…' : 'Measure outcome'}
+              </Button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function PreventionQueue() {
+  const queryClient = useQueryClient();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [logTarget, setLogTarget] = useState(null); // queue entry being acted on
+  const [logType, setLogType] = useState('');
+  const [logNotes, setLogNotes] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [expandedPatientId, setExpandedPatientId] = useState(null);
+
+  const { data: queueReport, isLoading, isError, refetch } = useQuery({
+    queryKey: ['actionQueue'],
+    queryFn: () => api.actionQueue.build({ size: 25 }),
+    refetchInterval: 120000,
+  });
+
+  const { data: effectiveness } = useQuery({
+    queryKey: ['preventionEffectiveness'],
+    queryFn: () => api.actionQueue.getInterventionEffectiveness({ windowDays: 90 }),
+    retry: false,
+  });
+
+  const { data: digest, error: digestError } = useQuery({
+    queryKey: ['preventionDigest'],
+    queryFn: () => api.actionQueue.buildDigest({}),
+    retry: false,
+  });
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await Promise.allSettled([
+      refetch(),
+      queryClient.invalidateQueries({ queryKey: ['preventionEffectiveness'] }),
+      queryClient.invalidateQueries({ queryKey: ['preventionDigest'] }),
+    ]);
+    setIsRefreshing(false);
+  };
+
+  const openLogDialog = (entry) => {
+    setLogTarget(entry);
+    setLogType(entry.recommendedAction?.actionType || 'other');
+    setLogNotes('');
+  };
+
+  const submitIntervention = async () => {
+    if (!logTarget) return;
+    setIsSaving(true);
+    try {
+      const r = await api.actionQueue.recordIntervention({
+        patientId: logTarget.patientId,
+        interventionType: logType,
+        targetFactor: logTarget.recommendedAction?.factor || null,
+        notes: logNotes || null,
+      });
+      toast.success(
+        `Action logged. Score at time of action: ${r?.assessmentBefore?.score ?? '—'} ` +
+        `(${r?.assessmentBefore?.riskLevel ?? ''}, model ${r?.assessmentBefore?.modelVersion ?? ''}).`
+      );
+      setLogTarget(null);
+      await queryClient.invalidateQueries({ queryKey: ['interventionHistory', logTarget.patientId] });
+      await queryClient.invalidateQueries({ queryKey: ['preventionEffectiveness'] });
+    } catch (err) {
+      toast.error(err?.message || 'Failed to record intervention.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
+        <RefreshCw className="w-8 h-8 animate-spin text-cyan-600" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState title="Action queue unavailable" />;
+  }
+
+  const impact = queueReport?.aggregateExpectedImpact;
+  const distribution = queueReport?.distribution || {};
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex justify-between items-center">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-900 flex items-center gap-3">
+              <ListChecks className="w-8 h-8 text-cyan-600" />
+              Prevention Action Queue
+            </h1>
+            <p className="text-slate-600 mt-1">
+              Ranked coordinator worklist to prevent waitlist inactivations
+              {queueReport?.modelVersion && (
+                <span className="text-slate-400"> • engine model {queueReport.modelVersion}</span>
+              )}
+            </p>
+          </div>
+          <Button onClick={handleRefresh} disabled={isRefreshing}>
+            <RefreshCw className={`w-4 h-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Non-clinical disclaimer */}
+        <Alert className="bg-blue-50 border-blue-200">
+          <Info className="h-4 w-4 text-blue-600" />
+          <AlertDescription className="text-blue-700 text-sm">
+            <strong>Non-Clinical Notice:</strong> This queue is an operational coordination signal.
+            It is not a clinical recommendation, and allocation decisions remain with OPTN/UNet.
+          </AlertDescription>
+        </Alert>
+
+        {/* Summary tiles */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          <Card className="border-cyan-200 bg-cyan-50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-cyan-700 flex items-center gap-2">
+                <Activity className="w-4 h-4" /> Patients Screened
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-cyan-900">{queueReport?.candidatesScreened ?? 0}</div>
+              <p className="text-xs text-cyan-600 mt-1">Active waitlist candidates</p>
+            </CardContent>
+          </Card>
+          <Card className="border-orange-200 bg-orange-50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-orange-700 flex items-center gap-2">
+                <Target className="w-4 h-4" /> In Queue
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-orange-900">{queueReport?.queueSize ?? 0}</div>
+              <p className="text-xs text-orange-600 mt-1">
+                {distribution.critical || 0} critical, {distribution.high || 0} high
+              </p>
+            </CardContent>
+          </Card>
+          <Card className="border-green-200 bg-green-50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-green-700 flex items-center gap-2">
+                <TrendingDown className="w-4 h-4" /> Projected Avoided
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-green-900">
+                {impact?.projectedInactivationsAvoidedWithin90Days ?? 0}
+              </div>
+              <p className="text-xs text-green-600 mt-1">Inactivations within 90 days if queue is worked</p>
+            </CardContent>
+          </Card>
+          <Card className="border-purple-200 bg-purple-50">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-purple-700 flex items-center gap-2">
+                <ClipboardCheck className="w-4 h-4" /> Actions Measured
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold text-purple-900">
+                {effectiveness?.totals?.measured ?? 0}
+                <span className="text-lg font-normal text-purple-600 ml-2">
+                  / {effectiveness?.totals?.recorded ?? 0}
+                </span>
+              </div>
+              <p className="text-xs text-purple-600 mt-1">Measured vs recorded (last {effectiveness?.windowDays ?? 90} days)</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Tabs defaultValue="queue" className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="queue">Action Queue</TabsTrigger>
+            <TabsTrigger value="outcomes">Measured Outcomes</TabsTrigger>
+            <TabsTrigger value="digest">Manager Digest</TabsTrigger>
+          </TabsList>
+
+          {/* Queue tab */}
+          <TabsContent value="queue">
+            <Card>
+              <CardHeader>
+                <CardTitle>Prioritized Patients</CardTitle>
+                <CardDescription>
+                  Ordered by risk score × evaluation-expiry urgency. Log the recommended action,
+                  then measure the outcome once the underlying issue is resolved.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {queueReport?.queue?.length > 0 ? (
+                  <div className="space-y-3">
+                    {queueReport.queue.map((entry, idx) => (
+                      <div key={entry.patientId} className="p-4 bg-slate-50 rounded-lg border">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="flex items-start gap-3">
+                            <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center font-bold text-sm shrink-0">
+                              {idx + 1}
+                            </div>
+                            <div>
+                              <div className="flex items-center gap-2 flex-wrap">
+                                <Link
+                                  to={`${createPageUrl('PatientDetails')}?id=${entry.patientId}`}
+                                  className="font-medium text-slate-900 hover:text-cyan-600"
+                                >
+                                  {entry.patientName || entry.patientId}
+                                </Link>
+                                {entry.mrn && <span className="text-xs text-slate-500">{entry.mrn}</span>}
+                                <Badge className={RISK_BADGE[entry.riskLevel] || RISK_BADGE.none}>
+                                  {entry.riskLevel} • {entry.score}
+                                </Badge>
+                                {entry.daysUntilEvaluationExpiry !== null &&
+                                  entry.daysUntilEvaluationExpiry !== undefined &&
+                                  entry.daysUntilEvaluationExpiry <= 30 && (
+                                  <Badge variant="outline" className="text-red-600 border-red-200 bg-red-50">
+                                    Eval expires in {entry.daysUntilEvaluationExpiry}d
+                                  </Badge>
+                                )}
+                              </div>
+                              <div className="text-xs text-slate-500 mt-1">
+                                90-day inactivation probability: <strong>{pct(entry.probabilityWithin90Days)}</strong>
+                                {entry.organNeeded && <span className="ml-2">• {entry.organNeeded}</span>}
+                              </div>
+                              {entry.recommendedAction && (
+                                <div className="mt-2 text-sm text-slate-700">
+                                  <span className="font-medium">Recommended:</span>{' '}
+                                  {entry.recommendedAction.actionDescription}
+                                  <span className="text-green-700 ml-2">
+                                    (−{entry.recommendedAction.expectedScoreReduction} pts →{' '}
+                                    {entry.recommendedAction.expectedNewRiskLevel})
+                                  </span>
+                                </div>
+                              )}
+                              {entry.topThreeFactors?.length > 0 && (
+                                <div className="flex gap-1 mt-2 flex-wrap">
+                                  {entry.topThreeFactors.map((f) => (
+                                    <Badge key={f.factor} variant="outline" className="text-xs">
+                                      {FACTOR_LABELS[f.factor] || f.factor}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex flex-col gap-2 shrink-0">
+                            <Button size="sm" onClick={() => openLogDialog(entry)}>
+                              Log Action
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                setExpandedPatientId(
+                                  expandedPatientId === entry.patientId ? null : entry.patientId
+                                )
+                              }
+                            >
+                              <History className="w-3.5 h-3.5 mr-1" />
+                              History
+                            </Button>
+                          </div>
+                        </div>
+                        {expandedPatientId === entry.patientId && (
+                          <div className="mt-3 border-t pt-2">
+                            <InterventionHistory
+                              patientId={entry.patientId}
+                              onChanged={handleRefresh}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-slate-500">
+                    <CheckCircle2 className="w-12 h-12 mx-auto mb-3 text-green-300" />
+                    <p className="font-medium">Queue is clear</p>
+                    <p className="text-sm">No patients currently require prevention actions</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Outcomes tab */}
+          <TabsContent value="outcomes">
+            <Card>
+              <CardHeader>
+                <CardTitle>Measured Intervention Effectiveness</CardTitle>
+                <CardDescription>
+                  Recorded coordinator actions and their measured before/after score deltas
+                  (last {effectiveness?.windowDays ?? 90} days)
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {effectiveness?.perInterventionType?.length > 0 ? (
+                  <div className="border rounded-lg overflow-hidden">
+                    <table className="w-full">
+                      <thead className="bg-slate-50 border-b">
+                        <tr>
+                          <th className="text-left px-4 py-3 text-sm font-medium text-slate-600">Intervention</th>
+                          <th className="text-center px-4 py-3 text-sm font-medium text-slate-600">Recorded</th>
+                          <th className="text-center px-4 py-3 text-sm font-medium text-slate-600">Measured</th>
+                          <th className="text-center px-4 py-3 text-sm font-medium text-slate-600">Avg Score Δ</th>
+                          <th className="text-center px-4 py-3 text-sm font-medium text-slate-600">Avg 90-day Prob Δ</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-100">
+                        {effectiveness.perInterventionType.map((row) => (
+                          <tr key={row.interventionType} className="hover:bg-slate-50">
+                            <td className="px-4 py-3 font-medium">
+                              {INTERVENTION_LABELS[row.interventionType] || row.interventionType}
+                            </td>
+                            <td className="px-4 py-3 text-center">{row.recorded}</td>
+                            <td className="px-4 py-3 text-center">{row.measured}</td>
+                            <td className="px-4 py-3 text-center">
+                              {row.averageScoreDelta ?? '—'}
+                            </td>
+                            <td className="px-4 py-3 text-center">
+                              {pct(row.averageProbability90Delta)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-slate-500">
+                    <ClipboardCheck className="w-12 h-12 mx-auto mb-3 text-slate-300" />
+                    <p>No interventions recorded in this window yet</p>
+                    <p className="text-sm mt-1">
+                      Log actions from the queue tab; measured outcomes appear here.
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Digest tab */}
+          <TabsContent value="digest">
+            <Card>
+              <CardHeader>
+                <CardTitle>Manager Prevention Digest</CardTitle>
+                <CardDescription>
+                  Center-level projection of prevented inactivations and preserved revenue
+                  {digest?.modelVersion && ` • engine model ${digest.modelVersion}`}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {digest?.headline ? (
+                  <div className="space-y-6">
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                      <div className="p-4 bg-slate-50 rounded-lg border">
+                        <div className="text-sm text-slate-600">Baseline expected inactivations</div>
+                        <div className="text-2xl font-bold text-slate-900">
+                          {digest.headline.expectedInactivationsBaseline}
+                        </div>
+                        <div className="text-xs text-slate-400">next 90 days, no action</div>
+                      </div>
+                      <div className="p-4 bg-slate-50 rounded-lg border">
+                        <div className="text-sm text-slate-600">After recommended actions</div>
+                        <div className="text-2xl font-bold text-slate-900">
+                          {digest.headline.expectedInactivationsAfterRecommendedActions}
+                        </div>
+                        <div className="text-xs text-slate-400">next 90 days, queue worked</div>
+                      </div>
+                      <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                        <div className="text-sm text-green-700">Inactivations avoided</div>
+                        <div className="text-2xl font-bold text-green-900">
+                          {digest.headline.inactivationsAvoided}
+                        </div>
+                      </div>
+                      <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                        <div className="text-sm text-green-700">Estimated dollars preserved</div>
+                        <div className="text-2xl font-bold text-green-900">
+                          ${Number(digest.headline.estimatedDollarsAvoided || 0).toLocaleString()}
+                        </div>
+                      </div>
+                    </div>
+
+                    {digest.headline.coordinatorOverloads?.length > 0 && (
+                      <Alert className="bg-amber-50 border-amber-200">
+                        <Info className="h-4 w-4 text-amber-600" />
+                        <AlertDescription className="text-amber-700 text-sm">
+                          <strong>Coordinator load imbalance:</strong>{' '}
+                          {digest.headline.coordinatorOverloads.length} coordinator(s) own a
+                          disproportionate share of at-risk patients. Consider rebalancing assignments.
+                        </AlertDescription>
+                      </Alert>
+                    )}
+
+                    {digest.disclaimer && (
+                      <p className="text-xs text-slate-400">{digest.disclaimer}</p>
+                    )}
+                  </div>
+                ) : digestError ? (
+                  <div className="text-center py-8 text-slate-500">
+                    <Info className="w-12 h-12 mx-auto mb-3 text-slate-300" />
+                    <p>{digestError.message?.includes('role')
+                      ? 'The manager digest requires an admin, coordinator, or regulator role.'
+                      : 'Digest unavailable.'}</p>
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-slate-500">
+                    <RefreshCw className="w-6 h-6 mx-auto animate-spin text-slate-300" />
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* Log-action dialog */}
+        <Dialog open={!!logTarget} onOpenChange={(open) => { if (!open) setLogTarget(null); }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Log Prevention Action</DialogTitle>
+              <DialogDescription>
+                {logTarget && (
+                  <>Recording an action for <strong>{logTarget.patientName || logTarget.patientId}</strong>.
+                  The engine score at this moment is captured as the “before” snapshot.</>
+                )}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="intervention-type">Action taken</Label>
+                <select
+                  id="intervention-type"
+                  className="w-full h-10 px-3 rounded-md border border-input bg-background text-sm"
+                  value={logType}
+                  onChange={(e) => setLogType(e.target.value)}
+                >
+                  {Object.entries(INTERVENTION_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>{label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="intervention-notes">Notes (optional)</Label>
+                <Textarea
+                  id="intervention-notes"
+                  value={logNotes}
+                  onChange={(e) => setLogNotes(e.target.value)}
+                  placeholder="e.g. Called patient, transportation barrier resolved with social work"
+                  rows={3}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setLogTarget(null)} disabled={isSaving}>
+                Cancel
+              </Button>
+              <Button onClick={submitIntervention} disabled={isSaving}>
+                {isSaving ? 'Saving…' : 'Record Action'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {queueReport?.disclaimer && (
+          <p className="text-xs text-slate-400">{queueReport.disclaimer}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/components/PreventionQueue.test.jsx
+++ b/tests/components/PreventionQueue.test.jsx
@@ -1,0 +1,225 @@
+/**
+ * PreventionQueue Page Component Tests
+ *
+ * Validates the inactivation prevention action queue UI:
+ * - Renders the page heading and non-clinical disclaimer
+ * - Renders ranked queue entries with recommended actions
+ * - Empty state when the queue is clear
+ * - Records an intervention through the Log Action dialog
+ * - Shows the measured-outcomes table
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HashRouter } from 'react-router-dom';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const QUEUE_REPORT = {
+  queueVersion: '1.0.0',
+  modelVersion: '2.0.0',
+  generatedAtISO: '2026-07-27T12:00:00Z',
+  candidatesScreened: 42,
+  queueSize: 2,
+  distribution: { critical: 1, high: 1, moderate: 5, low: 20, none: 15 },
+  queue: [
+    {
+      patientId: 'p1',
+      patientName: 'Jane Rivers',
+      mrn: 'MRN-001',
+      organNeeded: 'kidney',
+      score: 78.5,
+      riskLevel: 'critical',
+      probabilityWithin90Days: 0.62,
+      daysUntilEvaluationExpiry: 12,
+      queuePriority: 117.8,
+      recommendedAction: {
+        factor: 'EVAL_EXPIRY',
+        actionType: 'refreshEvaluation',
+        actionDescription: 'Schedule re-evaluation before expiry',
+        expectedScoreAfterAction: 48.2,
+        expectedScoreReduction: 30.3,
+        expectedNewRiskLevel: 'moderate',
+        expectedProbabilityReduction: 0.21,
+      },
+      topThreeFactors: [
+        { factor: 'EVAL_EXPIRY', weightedContribution: 30, shareOfScore: 0.4, rawSubscore: 100 },
+        { factor: 'BARRIERS', weightedContribution: 20, shareOfScore: 0.25, rawSubscore: 80 },
+      ],
+      modelVersion: '2.0.0',
+    },
+    {
+      patientId: 'p2',
+      patientName: 'Tom Okafor',
+      mrn: 'MRN-002',
+      organNeeded: 'liver',
+      score: 55.1,
+      riskLevel: 'high',
+      probabilityWithin90Days: 0.34,
+      daysUntilEvaluationExpiry: null,
+      queuePriority: 55.1,
+      recommendedAction: null,
+      topThreeFactors: [],
+      modelVersion: '2.0.0',
+    },
+  ],
+  coordinatorOverloads: [],
+  aggregateExpectedImpact: {
+    projectedProbabilityReductionWithin90Days: 0.21,
+    projectedInactivationsAvoidedWithin90Days: 0.2,
+  },
+  disclaimer: 'Operational coordination signal. Not a clinical recommendation.',
+};
+
+const EFFECTIVENESS = {
+  windowDays: 90,
+  perInterventionType: [
+    {
+      interventionType: 'refreshEvaluation',
+      recorded: 5,
+      measured: 3,
+      averageScoreDelta: 18.2,
+      averageProbability90Delta: 0.12,
+    },
+  ],
+  totals: { recorded: 5, measured: 3, weightedAvgScoreDelta: 18.2, weightedAvgProb90Delta: 0.12 },
+};
+
+const DIGEST = {
+  digestVersion: '1.0.0',
+  modelVersion: '2.0.0',
+  headline: {
+    activeCandidatesScreened: 42,
+    expectedInactivationsBaseline: 4.1,
+    expectedInactivationsAfterRecommendedActions: 2.9,
+    inactivationsAvoided: 1.2,
+    estimatedDollarsAvoided: 120000,
+    coordinatorOverloads: [],
+  },
+  disclaimer: 'Operational coordination signal.',
+};
+
+beforeEach(() => {
+  window.electronAPI = {
+    ...window.electronAPI,
+    actionQueue: {
+      build: vi.fn().mockResolvedValue(QUEUE_REPORT),
+      topInterventionsForPatient: vi.fn().mockResolvedValue({ topInterventions: [] }),
+      recordIntervention: vi.fn().mockResolvedValue({
+        id: 'iv1',
+        assessmentBefore: {
+          score: 78.5, riskLevel: 'critical',
+          probabilityWithin90Days: 0.62, modelVersion: '2.0.0',
+        },
+      }),
+      recordOutcome: vi.fn().mockResolvedValue({ updated: true, measured_score_delta: 12.5 }),
+      getInterventionsForPatient: vi.fn().mockResolvedValue([]),
+      getInterventionEffectiveness: vi.fn().mockResolvedValue(EFFECTIVENESS),
+      buildDigest: vi.fn().mockResolvedValue(DIGEST),
+    },
+  };
+});
+
+import PreventionQueue from '@/pages/PreventionQueue';
+
+function renderPreventionQueue() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <HashRouter>
+        <PreventionQueue />
+      </HashRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('PreventionQueue Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the page heading', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText('Prevention Action Queue')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the non-clinical disclaimer', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText(/Non-Clinical Notice/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders ranked queue entries with recommended actions', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText('Jane Rivers')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Tom Okafor')).toBeInTheDocument();
+    expect(screen.getByText(/Schedule re-evaluation before expiry/i)).toBeInTheDocument();
+    expect(screen.getByText(/Eval expires in 12d/i)).toBeInTheDocument();
+  });
+
+  it('shows summary tiles with screened and queue counts', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText('42')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 critical, 1 high/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when the queue is clear', async () => {
+    window.electronAPI.actionQueue.build.mockResolvedValueOnce({
+      ...QUEUE_REPORT,
+      queueSize: 0,
+      queue: [],
+    });
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText(/Queue is clear/i)).toBeInTheDocument();
+    });
+  });
+
+  it('records an intervention through the Log Action dialog', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText('Jane Rivers')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Log Action/i })[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Log Prevention Action')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Record Action/i }));
+    await waitFor(() => {
+      expect(window.electronAPI.actionQueue.recordIntervention).toHaveBeenCalledWith(
+        expect.objectContaining({
+          patientId: 'p1',
+          interventionType: 'refreshEvaluation',
+          targetFactor: 'EVAL_EXPIRY',
+        })
+      );
+    });
+  });
+
+  it('surfaces measured-outcome counts from the effectiveness report', async () => {
+    renderPreventionQueue();
+    await waitFor(() => {
+      expect(screen.getByText('Jane Rivers')).toBeInTheDocument();
+    });
+    // The "Actions Measured" tile renders measured/recorded from the report
+    await waitFor(() => {
+      expect(window.electronAPI.actionQueue.getInterventionEffectiveness).toHaveBeenCalled();
+      expect(screen.getByText('/ 5')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes all three open Medium pentest findings (PT-2026-06-001/002/003): OAuth introspection/revocation now require client authentication with token-ownership checks, SMART tokens are denied on native role-gated routes, and thin-client refresh tokens move to httpOnly cookies with access tokens in memory only.
- Wires the Inactivation Prevention Action Queue end-to-end into the UI: new Prevention Queue page with ranked worklist, intervention logging, measured outcomes, and manager digest, backed by the existing audited IPC surface.
- Adds CSV roster import to the Patients page plus the sample template referenced by the pilot runbook; adds an env-gated Epic production verification script (no PHI persisted).
- Hardens the renderer: production builds fail loudly if the Electron bridge is unavailable instead of silently serving dev placeholder data (PT-2026-06-006).
- Strengthens CI: adds a Server Tests job (lint + 83 unit tests) and raises the coverage hard floor from 8% to 15% (current: 20.5% lines).
- Fixes documentation drift and overclaims: licensing docs now match the real Ed25519 license system, compliance tables state self-assessed status honestly, and the user guide no longer claims bidirectional EHR sync.

## Test plan
- [x] Server: 83/83 unit tests pass, lint clean
- [x] Root: lint, type check, 126/126 Vitest component tests (incl. 7 new PreventionQueue tests), core Node suites pass
- [x] Coverage 20.5% lines / 24% branches, above the new 15% floor
- [x] Production build succeeds
- [ ] CI green on all required checks

Made with [Cursor](https://cursor.com)