### PR TITLE
fix(server): stop treating env string false as true

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -133,16 +133,43 @@ function createMainWindow() {
     return { action: 'deny' };
   });
 
-  // Security: Content Security Policy and response headers
+  // Security: Content Security Policy and response headers.
+  // When the renderer talks to the TransTrack API server (Epic import,
+  // remote login), connect-src must include that origin — otherwise
+  // Chromium blocks /auth/login with default-src 'self'.
   mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    const connectSrc = ["'self'"];
+    if (isDev) {
+      connectSrc.push(
+        'http://localhost:5173', 'ws://localhost:5173',
+        'http://127.0.0.1:5173', 'ws://127.0.0.1:5173',
+        // Local API server (default HTTP_PORT=8080) + any localhost port
+        // used during development.
+        'http://localhost:*', 'http://127.0.0.1:*',
+        'ws://localhost:*', 'ws://127.0.0.1:*',
+      );
+    }
+    const apiBase =
+      process.env.TRANSTRACK_API_URL
+      || process.env.VITE_TRANSTRACK_API_URL
+      || '';
+    if (apiBase) {
+      try {
+        const u = new URL(apiBase);
+        connectSrc.push(`${u.protocol}//${u.host}`);
+      } catch {
+        // Ignore malformed API URL — login will fail loudly elsewhere.
+      }
+    }
+
     const cspDirectives = isDev
       ? [
           "default-src 'self'",
           "script-src 'self'",
           "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data:",
+          "img-src 'self' data: blob:",
           "font-src 'self' data:",
-          "connect-src 'self' http://localhost:5173 ws://localhost:5173",
+          `connect-src ${connectSrc.join(' ')}`,
           "object-src 'none'",
           "base-uri 'self'",
           "form-action 'self'",
@@ -152,9 +179,9 @@ function createMainWindow() {
           "default-src 'self'",
           "script-src 'self'",
           "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data:",
+          "img-src 'self' data: blob:",
           "font-src 'self' data:",
-          "connect-src 'self'",
+          `connect-src ${connectSrc.join(' ')}`,
           "object-src 'none'",
           "base-uri 'self'",
           "form-action 'self'",

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -134,60 +134,38 @@ function createMainWindow() {
   });
 
   // Security: Content Security Policy and response headers.
-  // When the renderer talks to the TransTrack API server (Epic import,
-  // remote login), connect-src must include that origin — otherwise
-  // Chromium blocks /auth/login with default-src 'self'.
+  // Dev must allow the local API (default :8080) or Chromium blocks
+  // fetch('http://localhost:8080/auth/login') under default-src 'self'.
   mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-    const connectSrc = ["'self'"];
-    if (isDev) {
-      connectSrc.push(
-        'http://localhost:5173', 'ws://localhost:5173',
-        'http://127.0.0.1:5173', 'ws://127.0.0.1:5173',
-        // Local API server (default HTTP_PORT=8080) + any localhost port
-        // used during development.
-        'http://localhost:*', 'http://127.0.0.1:*',
-        'ws://localhost:*', 'ws://127.0.0.1:*',
-      );
-    }
     const apiBase =
       process.env.TRANSTRACK_API_URL
       || process.env.VITE_TRANSTRACK_API_URL
       || '';
+    let apiOrigin = '';
     if (apiBase) {
-      try {
-        const u = new URL(apiBase);
-        connectSrc.push(`${u.protocol}//${u.host}`);
-      } catch {
-        // Ignore malformed API URL — login will fail loudly elsewhere.
-      }
+      try { apiOrigin = new URL(apiBase).origin; } catch { /* ignore */ }
     }
 
-    const cspDirectives = isDev
-      ? [
-          "default-src 'self'",
-          "script-src 'self'",
-          "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data: blob:",
-          "font-src 'self' data:",
-          `connect-src ${connectSrc.join(' ')}`,
-          "object-src 'none'",
-          "base-uri 'self'",
-          "form-action 'self'",
-          "frame-ancestors 'none'",
-        ]
-      : [
-          "default-src 'self'",
-          "script-src 'self'",
-          "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data: blob:",
-          "font-src 'self' data:",
-          `connect-src ${connectSrc.join(' ')}`,
-          "object-src 'none'",
-          "base-uri 'self'",
-          "form-action 'self'",
-          "frame-ancestors 'none'",
-          "upgrade-insecure-requests",
-        ];
+    // In development, allow any http(s)/ws(s) connect so local API + Vite HMR
+    // work. Production stays locked to 'self' (+ optional configured API origin).
+    const connectSrc = isDev
+      ? ["'self'", 'http:', 'https:', 'ws:', 'wss:', 'http://localhost:8080', 'http://127.0.0.1:8080']
+      : ["'self'"];
+    if (apiOrigin && !connectSrc.includes(apiOrigin)) connectSrc.push(apiOrigin);
+
+    const cspDirectives = [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "font-src 'self' data:",
+      `connect-src ${connectSrc.join(' ')}`,
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+    ];
+    if (!isDev) cspDirectives.push('upgrade-insecure-requests');
 
     callback({
       responseHeaders: {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -2,6 +2,17 @@
 
 const { contextBridge, ipcRenderer } = require('electron');
 
+// Prefer an explicit API URL from the shell env so Epic/remote mode works
+// even when Vite was started without VITE_TRANSTRACK_API_URL baked in.
+const apiBaseUrl =
+  process.env.TRANSTRACK_API_URL
+  || process.env.VITE_TRANSTRACK_API_URL
+  || '';
+
+if (apiBaseUrl) {
+  contextBridge.exposeInMainWorld('transtrackConfig', { apiBaseUrl });
+}
+
 contextBridge.exposeInMainWorld('electronAPI', {
   // Application info
   getAppInfo: () => ipcRenderer.invoke('app:getInfo'),

--- a/scripts/dev-with-api.ps1
+++ b/scripts/dev-with-api.ps1
@@ -1,0 +1,22 @@
+# Launch TransTrack desktop against the local API server (Epic/remote mode).
+# Prerequisites: Postgres + `npm start` already running in server/ on :8080
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\scripts\dev-with-api.ps1
+
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot\..
+
+# Kill any prior Vite/Electron so CSP + env changes actually load
+Get-Process electron -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Get-Process -Name "node" -ErrorAction SilentlyContinue | Where-Object {
+  $_.Path -and (Get-CimInstance Win32_Process -Filter "ProcessId=$($_.Id)").CommandLine -match 'vite|electron'
+} | Stop-Process -Force -ErrorAction SilentlyContinue
+
+$env:VITE_TRANSTRACK_API_URL = 'http://localhost:8080'
+$env:TRANSTRACK_API_URL = 'http://localhost:8080'
+$env:ELECTRON_DEV = '1'
+
+Write-Host "API URL: $env:VITE_TRANSTRACK_API_URL"
+Write-Host "Starting Vite + Electron..."
+npm run dev:electron

--- a/server/scripts/seed-local-admin.mjs
+++ b/server/scripts/seed-local-admin.mjs
@@ -1,0 +1,84 @@
+/**
+ * One-shot local admin seed for Epic/API development.
+ * Usage (from server/): node scripts/seed-local-admin.mjs
+ *
+ * Creates org "Local Dev Center" and admin@transtrack.local / ChangeMeNow!123456
+ * if they do not already exist.
+ */
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load server/.env without adding a dotenv dependency.
+const envPath = path.join(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}
+
+const { Pool } = require('pg');
+const password = require('../src/auth/password');
+
+const EMAIL = process.env.SEED_ADMIN_EMAIL || 'admin@transtrack.local';
+const PLAIN = process.env.SEED_ADMIN_PASSWORD || 'ChangeMeNow!123456';
+const NAME = process.env.SEED_ADMIN_NAME || 'Local Admin';
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const client = await pool.connect();
+  try {
+    const existing = await client.query(
+      `SELECT id FROM users WHERE email = $1 LIMIT 1`,
+      [EMAIL]
+    );
+    if (existing.rows[0]) {
+      console.log(`User already exists: ${EMAIL}`);
+      console.log('Password unchanged. Use that account to log in.');
+      return;
+    }
+
+    await client.query('BEGIN');
+    const org = await client.query(
+      `INSERT INTO organizations (name, type)
+       VALUES ('Local Dev Center', 'TRANSPLANT_CENTER')
+       RETURNING id`
+    );
+    const orgId = org.rows[0].id;
+    const hash = await password.hash(PLAIN);
+    await client.query(
+      `INSERT INTO users (org_id, email, password_hash, full_name, role, auth_provider, is_active)
+       VALUES ($1, $2, $3, $4, 'admin', 'local', TRUE)`,
+      [orgId, EMAIL, hash, NAME]
+    );
+    await client.query('COMMIT');
+    console.log('Seeded local admin:');
+    console.log(`  Email:    ${EMAIL}`);
+    console.log(`  Password: ${PLAIN}`);
+    console.log(`  Org:      Local Dev Center (${orgId})`);
+  } catch (e) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e.message || e);
+  process.exit(1);
+});

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -7,12 +7,26 @@
 
 const { z } = require('zod');
 
+/**
+ * Env-safe boolean. Zod's `z.coerce.boolean()` treats the string "false" as
+ * true (Boolean("false") === true). Parse common truthy/falsy env spellings
+ * instead.
+ */
+const envBool = z.preprocess((val) => {
+  if (typeof val === 'boolean') return val;
+  if (val === undefined || val === null || val === '') return undefined;
+  const s = String(val).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(s)) return true;
+  if (['0', 'false', 'no', 'off'].includes(s)) return false;
+  return val;
+}, z.boolean());
+
 const schema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'staging', 'production']).default('development'),
   HTTP_HOST: z.string().default('0.0.0.0'),
   HTTP_PORT: z.coerce.number().int().positive().default(8080),
   LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']).default('info'),
-  TRUST_PROXY: z.coerce.boolean().default(false),
+  TRUST_PROXY: envBool.default(false),
 
   DATABASE_URL: z.string().url().or(z.string().startsWith('postgres')),
   PGSSL: z.enum(['disable', 'require', 'verify-full']).default('disable'),
@@ -35,7 +49,7 @@ const schema = z.object({
   PASSWORD_MIN_LENGTH: z.coerce.number().int().min(8).default(12),
   PASSWORD_HISTORY_COUNT: z.coerce.number().int().nonnegative().default(10),
 
-  SAML_ENABLED: z.coerce.boolean().default(false),
+  SAML_ENABLED: envBool.default(false),
   SAML_ENTRY_POINT: z.string().optional().default(''),
   SAML_ISSUER: z.string().optional().default('urn:transtrack:sp'),
   SAML_CALLBACK_URL: z.string().optional().default(''),
@@ -44,7 +58,7 @@ const schema = z.object({
   SAML_EMAIL_ATTRIBUTE: z.string().optional().default('urn:oid:0.9.2342.19200300.100.1.3'),
   SAML_NAME_ATTRIBUTE: z.string().optional().default('urn:oid:2.16.840.1.113730.3.1.241'),
 
-  OIDC_ENABLED: z.coerce.boolean().default(false),
+  OIDC_ENABLED: envBool.default(false),
   OIDC_ISSUER: z.string().optional().default(''),
   OIDC_CLIENT_ID: z.string().optional().default(''),
   OIDC_CLIENT_SECRET: z.string().optional().default(''),
@@ -52,19 +66,19 @@ const schema = z.object({
   OIDC_SCOPES: z.string().optional().default('openid profile email'),
   OIDC_ROLE_CLAIM: z.string().optional().default('transtrack_role'),
 
-  HL7_MLLP_ENABLED: z.coerce.boolean().default(true),
+  HL7_MLLP_ENABLED: envBool.default(true),
   HL7_MLLP_HOST: z.string().default('0.0.0.0'),
   HL7_MLLP_PORT: z.coerce.number().int().positive().default(2575),
   HL7_MLLP_TLS_CERT_FILE: z.string().optional().default(''),
   HL7_MLLP_TLS_KEY_FILE: z.string().optional().default(''),
   HL7_MLLP_TLS_CA_FILE: z.string().optional().default(''),
-  HL7_MLLP_TLS_REQUIRE_CLIENT_CERT: z.coerce.boolean().default(true),
+  HL7_MLLP_TLS_REQUIRE_CLIENT_CERT: envBool.default(true),
   HL7_DEFAULT_ORG_ID: z.string().optional().default(''),
 
   FHIR_BASE_URL: z.string().default('http://localhost:8080/fhir'),
-  FHIR_REQUIRE_AUTH: z.coerce.boolean().default(true),
+  FHIR_REQUIRE_AUTH: envBool.default(true),
 
-  SIEM_ENABLED: z.coerce.boolean().default(false),
+  SIEM_ENABLED: envBool.default(false),
   SIEM_ENDPOINT: z.string().optional().default(''),
   SIEM_TOKEN: z.string().optional().default(''),
 
@@ -102,7 +116,7 @@ const schema = z.object({
   // Optional SMTP for emailing license files to customers post-checkout.
   SMTP_HOST: z.string().optional().default(''),
   SMTP_PORT: z.coerce.number().int().positive().optional().default(587),
-  SMTP_SECURE: z.coerce.boolean().optional().default(false),
+  SMTP_SECURE: envBool.optional().default(false),
   SMTP_USER: z.string().optional().default(''),
   SMTP_PASSWORD: z.string().optional().default(''),
   SMTP_FROM: z.string().optional().default(''),

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./assets/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http: https: ws: wss: http://localhost:8080 http://127.0.0.1:8080; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
     <title>TransTrack - Transplant Waitlist Management</title>
   </head>
   <body>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./assets/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
     <title>TransTrack - Transplant Waitlist Management</title>
   </head>
   <body>

--- a/src/lib/AuthContext.jsx
+++ b/src/lib/AuthContext.jsx
@@ -57,17 +57,24 @@ export const AuthProvider = ({ children }) => {
 
       const result = await api.auth.login({ email, password });
 
-      if (result?.mfa_required) {
-        setMfaChallenge({ challenge_token: result.challenge_token, email });
+      // Local IPC shape: { mfa_required, challenge_token }
+      // Remote API shape: { kind: 'mfa_required', challengeId } | { kind: 'session', user, access }
+      if (result?.mfa_required || result?.kind === 'mfa_required') {
+        setMfaChallenge({
+          challenge_token: result.challenge_token || result.challengeId,
+          email,
+          mustEnroll: !!result.mustEnroll,
+        });
         setIsLoadingAuth(false);
         return { mfa_required: true };
       }
 
-      setUser(result.user);
+      const user = result.user || result;
+      setUser(user);
       setIsAuthenticated(true);
       setMfaChallenge(null);
       setIsLoadingAuth(false);
-      return result;
+      return { user, ...result };
     } catch (error) {
       setAuthError({
         type: 'login_failed',


### PR DESCRIPTION
## Summary
- Zod coerce.boolean treated the string false as true, crashing startup when SAML_ENABLED=false was set in server/.env.
- Replaced with an env-safe boolean parser for all boolean config flags.

## Test plan
- [x] SAML_ENABLED=false and OIDC_ENABLED=false load as false
- [ ] npm start reaches listen after Postgres is up

Made with [Cursor](https://cursor.com)