### PR TITLE
chore(ci): disable Dependabot PR creation until requested

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
-    # Keep the PR queue tiny so Dependabot cannot flood the repo.
-    open-pull-requests-limit: 2
+    # Disabled until dependency updates are requested intentionally.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     commit-message:
@@ -30,7 +30,7 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "server"
@@ -47,7 +47,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary
- Set all Dependabot open-pull-requests-limit values to 0 so it cannot open more PRs.
- Re-enable intentionally when you want dependency bumps.

## Test plan
- [ ] No new Dependabot PRs appear after merge


Made with [Cursor](https://cursor.com)