### PR TITLE
fix(security): drop legacy SHA-256 MFA recovery hashes (CodeQL #48)

### DIFF
--- a/server/src/auth/mfa.js
+++ b/server/src/auth/mfa.js
@@ -110,37 +110,16 @@ function normalizeRecoveryCode(code) {
   return String(code || '').toUpperCase().trim();
 }
 
-function isLegacySha256Hash(stored) {
-  return typeof stored === 'string' && /^[a-f0-9]{64}$/i.test(stored);
-}
-
-/**
- * Hash a recovery code with Argon2id (same parameters as passwords).
- * Legacy SHA-256 hashes are still accepted by verifyRecoveryCode.
- */
+/** Hash a recovery code with Argon2id (same parameters as passwords). */
 async function hashRecoveryCode(code) {
   return password.hash(normalizeRecoveryCode(code));
 }
 
-/**
- * Verify a recovery code against a stored hash.
- * Supports Argon2id and legacy SHA-256 hex digests.
- */
+/** Verify a recovery code against an Argon2id stored hash. */
 async function verifyRecoveryCode(code, storedHash) {
   if (!storedHash) return false;
   const normalized = normalizeRecoveryCode(code);
   if (!normalized) return false;
-  if (isLegacySha256Hash(storedHash)) {
-    const legacy = crypto.createHash('sha256').update(normalized).digest('hex');
-    try {
-      return crypto.timingSafeEqual(
-        Buffer.from(legacy, 'utf8'),
-        Buffer.from(storedHash.toLowerCase(), 'utf8')
-      );
-    } catch {
-      return false;
-    }
-  }
   return password.verify(storedHash, normalized);
 }
 
@@ -153,7 +132,6 @@ module.exports = {
   generateRecoveryCodes,
   hashRecoveryCode,
   verifyRecoveryCode,
-  isLegacySha256Hash,
   encryptSecret,
   decryptSecret,
 };

--- a/server/src/services/authService.js
+++ b/server/src/services/authService.js
@@ -204,16 +204,13 @@ async function consumeMfaChallenge(client, config, { challengeId, code, ip, user
   const secret = mfa.decryptSecret(ch.secret_encrypted, config.JWT_SECRET);
   const ok = mfa.verifyCode(secret, code);
   if (!ok) {
-    // Try recovery codes (one-time). Argon2id (with legacy SHA-256 upgrade).
+    // Try recovery codes (one-time), stored as Argon2id hashes.
     const list = ch.recovery_codes || [];
     let matched = false;
     for (let i = 0; i < list.length; i++) {
       if (list[i].used_at) continue;
       if (!(await mfa.verifyRecoveryCode(code, list[i].hash))) continue;
       list[i].used_at = new Date().toISOString();
-      if (mfa.isLegacySha256Hash(list[i].hash)) {
-        list[i].hash = await mfa.hashRecoveryCode(code);
-      }
       matched = true;
       break;
     }
@@ -458,9 +455,6 @@ async function verifySmartMfa({ challengeId, code, userId }) {
         if (list[i].used_at) continue;
         if (!(await mfa.verifyRecoveryCode(code, list[i].hash))) continue;
         list[i].used_at = new Date().toISOString();
-        if (mfa.isLegacySha256Hash(list[i].hash)) {
-          list[i].hash = await mfa.hashRecoveryCode(code);
-        }
         matched = true;
         break;
       }

--- a/server/test/unit/mfa.test.mjs
+++ b/server/test/unit/mfa.test.mjs
@@ -41,14 +41,6 @@ describe('mfa', () => {
     expect(await mfa.verifyRecoveryCode('DEADBEEFDEADBEEFDEAD', hash)).toBe(false);
   });
 
-  it('still accepts legacy SHA-256 recovery hashes', async () => {
-    const code = 'ABCDEF1234567890ABCD';
-    const crypto = require('crypto');
-    const legacy = crypto.createHash('sha256').update(code).digest('hex');
-    expect(mfa.isLegacySha256Hash(legacy)).toBe(true);
-    expect(await mfa.verifyRecoveryCode(code, legacy)).toBe(true);
-  });
-
   it('builds an otpauth URI', () => {
     const secret = mfa.generateSecret();
     const uri = mfa.buildOtpauthUrl({


### PR DESCRIPTION
## Summary
PR #220 fixed alerts #45/#46/#47 but left a legacy SHA-256 verify path that CodeQL flagged as **#48**.

Removes legacy SHA-256 recovery-code hashing entirely. Recovery codes are Argon2id-only (same as passwords). Users with pre-#220 recovery codes must re-enroll MFA / regenerate recovery codes.

## Test plan
- [x] MFA unit tests pass
- [ ] CodeQL gate green (no new high alerts)
- [ ] Open code-scanning alerts on main = 0 after merge


Made with [Cursor](https://cursor.com)