### PR TITLE
fix(phi): open the patient record when access justification is confirmed

### DIFF
--- a/src/components/access/JustificationDialog.jsx
+++ b/src/components/access/JustificationDialog.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -24,14 +24,37 @@ export default function JustificationDialog({ open, onConfirm, onCancel, entityT
     'Emergency access',
   ];
 
+  // Radix closes the dialog itself when either footer button is pressed, so the
+  // resulting onOpenChange(false) cannot be read as "the user cancelled" — that
+  // fired onCancel on the confirm path too, cancelling the access request that
+  // was still in flight. This records which button caused the close.
+  const confirmedRef = useRef(false);
+
   const handleSubmit = () => {
     if (!justification.trim()) return;
+    confirmedRef.current = true;
     onConfirm(justification.trim());
     setJustification('');
   };
 
+  // Single cancel path: every close that was not a confirm routes through here,
+  // whether it came from the Cancel button, Escape, or the overlay. The Cancel
+  // button deliberately carries no onClick of its own, so cancelling fires
+  // exactly one onCancel rather than two.
+  const handleOpenChange = (isOpen) => {
+    if (isOpen) {
+      confirmedRef.current = false;
+      return;
+    }
+    if (confirmedRef.current) {
+      confirmedRef.current = false;
+      return;
+    }
+    onCancel();
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent className="max-w-md">
         <AlertDialogHeader>
           <AlertDialogTitle className="flex items-center gap-2">
@@ -72,7 +95,7 @@ export default function JustificationDialog({ open, onConfirm, onCancel, entityT
         </div>
 
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction onClick={handleSubmit} disabled={!justification.trim()}>
             Confirm Access
           </AlertDialogAction>

--- a/src/hooks/useJustifiedAccess.js
+++ b/src/hooks/useJustifiedAccess.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 
 /**
  * Hook for handling access with justification requirements.
@@ -12,6 +12,11 @@ import { useState, useCallback } from 'react';
 export function useJustifiedAccess() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState(null);
+  // The authorization IPC is async, so the dialog can emit a close event while
+  // it is still running. A promise settles once, so a cancellation arriving in
+  // that window would permanently decide the outcome as "denied" no matter what
+  // the grant came back as. This lets handleCancel stand down instead.
+  const confirmInFlight = useRef(false);
 
   const requireJustification = useCallback((permission, entityType, entityId) => {
     return new Promise((resolve) => {
@@ -32,6 +37,7 @@ export function useJustifiedAccess() {
       ? justification
       : justification?.details || justification?.reason || '';
 
+    confirmInFlight.current = true;
     try {
       const ipc = window.electronAPI?.accessControl?.authorizePhiAccess;
       if (ipc) {
@@ -51,12 +57,18 @@ export function useJustifiedAccess() {
       }
     } catch (err) {
       pendingAction.resolve({ authorized: false, reason: err.message });
+    } finally {
+      confirmInFlight.current = false;
+      setPendingAction(null);
+      setDialogOpen(false);
     }
-    setPendingAction(null);
-    setDialogOpen(false);
   }, [pendingAction]);
 
   const handleCancel = useCallback(() => {
+    // A confirm already owns this request's outcome; ignore the close event it
+    // caused rather than resolving the promise as a cancellation.
+    if (confirmInFlight.current) return;
+
     if (pendingAction) {
       pendingAction.resolve({
         authorized: false,

--- a/src/pages/PatientDetails.jsx
+++ b/src/pages/PatientDetails.jsx
@@ -27,6 +27,7 @@ export default function PatientDetails() {
   const queryClient = useQueryClient();
   const { requireJustification, dialogOpen, handleConfirm, handleCancel, pendingAction } = useJustifiedAccess();
   const [accessGranted, setAccessGranted] = useState(false);
+  const [accessDenied, setAccessDenied] = useState(null);
 
   useEffect(() => {
     if (patientId && !accessGranted) {
@@ -39,6 +40,11 @@ export default function PatientDetails() {
               stack: `Patient ID: ${patientId}`,
             }).catch(() => {});
           }
+        } else if (!result.cancelled) {
+          // Denied rather than cancelled (permission, justification too short,
+          // an IPC failure). Surface why instead of leaving the page waiting on
+          // a dialog that has already closed.
+          setAccessDenied(result.reason || 'Access to this record was denied.');
         }
       });
     }
@@ -77,7 +83,18 @@ export default function PatientDetails() {
           action="view"
         />
         <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6 flex items-center justify-center">
-          <div className="text-slate-600">Awaiting access justification...</div>
+          {accessDenied ? (
+            <div className="text-center space-y-4">
+              <div className="text-slate-800 font-medium">Access not granted</div>
+              <div className="text-slate-600 text-sm max-w-md">{accessDenied}</div>
+              <Button variant="outline" onClick={() => window.history.back()}>
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                Go Back
+              </Button>
+            </div>
+          ) : (
+            <div className="text-slate-600">Awaiting access justification...</div>
+          )}
         </div>
       </>
     );

--- a/tests/components/JustificationAccessFlow.test.jsx
+++ b/tests/components/JustificationAccessFlow.test.jsx
@@ -1,0 +1,262 @@
+/**
+ * PHI Access Justification Flow — integration between the real dialog and the
+ * real hook.
+ *
+ * REGRESSION CONTEXT: clicking "Confirm Access" used to bounce the user back to
+ * the previous page without ever opening the record. Radix's AlertDialogAction
+ * closes the dialog itself, so the resulting onOpenChange(false) fired the
+ * cancel path while the authorization IPC was still in flight. handleCancel
+ * settled the promise as cancelled first, and because a promise resolves once,
+ * the real grant that arrived moments later was discarded. Every route into a
+ * patient record was affected.
+ *
+ * The existing PatientDetails suite mocks BOTH useJustifiedAccess and
+ * JustificationDialog, so the interaction between them was never exercised and
+ * the bug passed CI. These tests deliberately use the real implementations of
+ * both and drive them through actual user events.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import JustificationDialog from '@/components/access/JustificationDialog';
+import { useJustifiedAccess } from '@/hooks/useJustifiedAccess';
+
+const PERMISSION = 'patient:view_phi';
+const ENTITY_TYPE = 'Patient';
+const ENTITY_ID = 'pat-1';
+
+/**
+ * Minimal stand-in for the PatientDetails gate: request justification on mount,
+ * render the real dialog, and record how the request resolved.
+ */
+function AccessHarness({ onResolved, onCancelSpy }) {
+  const { requireJustification, dialogOpen, handleConfirm, handleCancel } = useJustifiedAccess();
+  const requested = React.useRef(false);
+
+  React.useEffect(() => {
+    if (requested.current) return;
+    requested.current = true;
+    requireJustification(PERMISSION, ENTITY_TYPE, ENTITY_ID).then(onResolved);
+  }, [requireJustification, onResolved]);
+
+  return (
+    <JustificationDialog
+      open={dialogOpen}
+      onConfirm={handleConfirm}
+      onCancel={() => {
+        onCancelSpy();
+        handleCancel();
+      }}
+      entityType="patient"
+      action="view"
+    />
+  );
+}
+
+function setupIpc(impl) {
+  const authorizePhiAccess = vi.fn(impl);
+  window.electronAPI = { ...window.electronAPI, accessControl: { authorizePhiAccess } };
+  return authorizePhiAccess;
+}
+
+describe('PHI access justification flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('grants access when a reason is chosen and Confirm Access is pressed', async () => {
+    const user = userEvent.setup();
+    const ipc = setupIpc(async () => ({ granted: true, grantId: 'grant-1' }));
+    const onResolved = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={onCancelSpy} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Direct patient care' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    // The core regression: the request must resolve as authorized, not cancelled.
+    expect(onResolved.mock.calls[0][0]).toMatchObject({
+      authorized: true,
+      justification: 'Direct patient care',
+      grantId: 'grant-1',
+    });
+    expect(onResolved.mock.calls[0][0].cancelled).toBeUndefined();
+
+    expect(ipc).toHaveBeenCalledTimes(1);
+    expect(ipc).toHaveBeenCalledWith({
+      permission: PERMISSION,
+      entityType: ENTITY_TYPE,
+      entityId: ENTITY_ID,
+      justification: 'Direct patient care',
+    });
+  });
+
+  it('does not fire the cancel path when access is confirmed', async () => {
+    // PatientDetails calls window.history.back() from onCancel, so a spurious
+    // cancel is what navigated the user away from the record they opened.
+    const user = userEvent.setup();
+    setupIpc(async () => ({ granted: true, grantId: 'grant-2' }));
+    const onResolved = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={onCancelSpy} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Clinical review' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onCancelSpy).not.toHaveBeenCalled();
+  });
+
+  it('still resolves as authorized when the IPC is slow', async () => {
+    // The original defect was a race: the dialog's close event beat the IPC.
+    // Delaying the response keeps that ordering pinned.
+    const user = userEvent.setup();
+    setupIpc(() => new Promise((resolve) => {
+      setTimeout(() => resolve({ granted: true, grantId: 'grant-slow' }), 50);
+    }));
+    const onResolved = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={onCancelSpy} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Care coordination' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1), { timeout: 3000 });
+    expect(onResolved.mock.calls[0][0].authorized).toBe(true);
+    expect(onCancelSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a typed custom justification', async () => {
+    const user = userEvent.setup();
+    const ipc = setupIpc(async () => ({ granted: true, grantId: 'grant-3' }));
+    const onResolved = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={vi.fn()} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.type(
+      screen.getByPlaceholderText(/type a custom justification/i),
+      'Reviewing labs ahead of transplant board'
+    );
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(ipc.mock.calls[0][0].justification).toBe('Reviewing labs ahead of transplant board');
+    expect(onResolved.mock.calls[0][0].authorized).toBe(true);
+  });
+
+  it('cannot be confirmed without a justification', async () => {
+    const user = userEvent.setup();
+    const ipc = setupIpc(async () => ({ granted: true }));
+    const onResolved = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={vi.fn()} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    const confirm = screen.getByRole('button', { name: /Confirm Access/i });
+    expect(confirm).toBeDisabled();
+
+    await user.click(confirm);
+    expect(ipc).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it('reports a denial with its reason instead of hanging', async () => {
+    // A denied request must resolve too, otherwise the caller waits forever on
+    // a dialog that has already closed.
+    const user = userEvent.setup();
+    setupIpc(async () => ({ granted: false, reason: 'Justification must be at least 10 characters' }));
+    const onResolved = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={vi.fn()} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Emergency access' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onResolved.mock.calls[0][0]).toMatchObject({
+      authorized: false,
+      reason: 'Justification must be at least 10 characters',
+    });
+    // Not a cancellation — the caller needs to tell these apart to decide
+    // between navigating back and showing the reason.
+    expect(onResolved.mock.calls[0][0].cancelled).toBeUndefined();
+  });
+
+  it('reports a thrown IPC error as denied rather than granted', async () => {
+    const user = userEvent.setup();
+    setupIpc(async () => { throw new Error('Session expired. Please log in again.'); });
+    const onResolved = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={vi.fn()} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Direct patient care' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onResolved.mock.calls[0][0].authorized).toBe(false);
+    expect(onResolved.mock.calls[0][0].reason).toMatch(/Session expired/);
+  });
+
+  it('cancels exactly once when the Cancel button is used', async () => {
+    // Cancel previously fired onCancel twice (its own onClick plus the close
+    // event), so PatientDetails ran window.history.back() twice and skipped a
+    // page. Exactly one cancellation must be emitted.
+    const user = userEvent.setup();
+    setupIpc(async () => ({ granted: true }));
+    const onResolved = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={onCancelSpy} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: /^Cancel$/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    expect(onResolved.mock.calls[0][0]).toMatchObject({ authorized: false, cancelled: true });
+  });
+
+  it('treats an Escape key dismissal as a cancellation', async () => {
+    const user = userEvent.setup();
+    setupIpc(async () => ({ granted: true }));
+    const onResolved = vi.fn();
+    const onCancelSpy = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={onCancelSpy} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    expect(onResolved.mock.calls[0][0].cancelled).toBe(true);
+  });
+
+  it('resolves as authorized outside Electron, where the bridge is absent', async () => {
+    const user = userEvent.setup();
+    window.electronAPI = { ...window.electronAPI, accessControl: undefined };
+    const onResolved = vi.fn();
+
+    render(<AccessHarness onResolved={onResolved} onCancelSpy={vi.fn()} />);
+
+    await screen.findByText(/Access Justification Required/i);
+    await user.click(screen.getByRole('button', { name: 'Direct patient care' }));
+    await user.click(screen.getByRole('button', { name: /Confirm Access/i }));
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    expect(onResolved.mock.calls[0][0].authorized).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

In the Risk Intel dashboard, clicking **View** next to a patient (aHHQ, Lab Currency, Readiness Barriers tabs) opens the access-justification prompt. Selecting a reason and clicking **Confirm Access** returned the user to the dashboard without ever opening the record.

## Root cause

Radix's `AlertDialogAction` closes the dialog itself, so pressing **Confirm Access** fired `onOpenChange(false)` in addition to the submit handler. The dialog treated any close as a cancellation:

`<AlertDialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>`

That ran the cancel path while the `access:authorizePhiAccess` IPC was still in flight. `handleCancel` settled the request as cancelled first, and because a promise resolves only once, the real grant arriving moments later was discarded — so `accessGranted` stayed false and `PatientDetails`'s `onCancel` had already called `window.history.back()`.

This affected **every** route into a patient record, not just the two tabs reported.

A second defect: **Cancel** invoked `onCancel` twice (its own `onClick` plus the close event), so `window.history.back()` ran twice and skipped a page.

## Changes

- `JustificationDialog` records which button caused the close, so a confirm is no longer read as a cancellation. All non-confirm closes (Cancel, Escape, overlay) route through a single cancel path, emitting exactly one `onCancel`.
- `useJustifiedAccess` ignores a cancellation while a confirm owns the outcome — defence in depth against the same race.
- `PatientDetails` distinguishes *denied* from *cancelled* and shows the reason with a way back, instead of waiting forever on a dialog that already closed. This is what a `viewer`/`user`/`regulator` role (no `patient:view_phi`) would previously have hit.

## Why CI missed it

`tests/components/PatientDetails.test.jsx` mocks **both** `useJustifiedAccess` and `JustificationDialog`, so their interaction was never exercised.

## Testing

New `tests/components/JustificationAccessFlow.test.jsx` drives the **real** dialog and **real** hook through actual user events: confirm, slow IPC, custom text, empty justification, denial, thrown IPC error, Cancel, and Escape.

Verified the suite genuinely reproduces the bug — against the pre-fix code **7 of 10 fail**, including the double-cancel; all 10 pass after.

- 10/10 new tests pass
- 137/137 component tests pass
- 37/37 Electron suites pass
- lint clean, production build clean

## Epic Connection Hub

Not touched. The change is confined to three renderer files; no main-process, FHIR, HL7, or EHR code is modified.

Made with [Cursor](https://cursor.com)